### PR TITLE
Fix PackBuilder not generating files related to additional status

### DIFF
--- a/src/main/java/net/worldseed/resourcepack/PackBuilder.java
+++ b/src/main/java/net/worldseed/resourcepack/PackBuilder.java
@@ -68,7 +68,7 @@ public class PackBuilder {
                                 }
 
                                 String modelName = pathName.toString().replace("\\", "/");
-                                return new Model(Files.readString(entityModel, StandardCharsets.UTF_8), modelName, additionalStateFiles.get(entityModel));
+                                return new Model(Files.readString(entityModel, StandardCharsets.UTF_8), modelName, additionalStateFiles.get(pathName));
                             } catch (IOException e) {
                                 throw new RuntimeException(e);
                             }


### PR DESCRIPTION
## Overview

I fixed an issue where incorrect keys were passed to `additionalStateFiles#get` within `PackBuilder#recursiveFileSearch`, preventing the generation of additional status files.