### PR TITLE
Update to 1.21.11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 java = "25"
 junit = "6.0.0-M2"
-minestom = "2025.10.11-1.21.10"
+minestom = "2025.12.20-1.21.11"
 commons-io = "2.20.0"
 zt-zip = "1.17"
 javax-json = "1.1.4"

--- a/src/main/java/net/worldseed/resourcepack/PackBuilder.java
+++ b/src/main/java/net/worldseed/resourcepack/PackBuilder.java
@@ -35,7 +35,7 @@ public class PackBuilder {
 
         List<Model> entityModels = recursiveFileSearch(bbmodel, bbmodel, additionalStateFiles);
 
-        Path texturePathMobs = resourcepack.resolve("assets/worldseed/textures/mobs/");
+        Path texturePathMobs = resourcepack.resolve("assets/worldseed/textures/item/");
         Path modelPathMobs = resourcepack.resolve("assets/worldseed/models/mobs/");
         Path baseModelPath = resourcepack.resolve("assets/minecraft/items/");
 

--- a/src/main/java/net/worldseed/resourcepack/multipart/parser/ModelParser.java
+++ b/src/main/java/net/worldseed/resourcepack/multipart/parser/ModelParser.java
@@ -249,7 +249,7 @@ public class ModelParser {
 
         JsonObjectBuilder modelTextureJson = Json.createObjectBuilder();
         for (Map.Entry<String, TextureGenerator.TextureData> t : bbModel.textures().entrySet()) {
-            modelTextureJson.add(t.getKey(), "worldseed:mobs/" + bbModel.id() + "/" + state.name() + "/" + t.getKey());
+            modelTextureJson.add(t.getKey(), "worldseed:item/" + bbModel.id() + "/" + state.name() + "/" + t.getKey());
 
             byte[] textureByte = t.getValue().value();
             BufferedImage texture = ImageIO.read(new BufferedInputStream(new ByteArrayInputStream(textureByte)));
@@ -328,7 +328,7 @@ public class ModelParser {
                     JsonObjectBuilder modelTextureJson = Json.createObjectBuilder();
 
                     for (var t : modelFile.textures.keySet()) {
-                        modelTextureJson.add(t, "worldseed:mobs/" + bbModel.id() + "/" + state.name + "/" + subBone.getValue());
+                        modelTextureJson.add(t, "worldseed:item/" + bbModel.id() + "/" + state.name + "/" + subBone.getValue());
                     }
 
                     var subbones = bones.stream()


### PR DESCRIPTION
## Overview
This updates to Minestom 1.21.11, and fixes an issue on 1.21.11 clients not loading the textures properly when the default `src/test/resources/resourcepack_template` is not used.

## Investigation
While working on a local project using 1.21.11 and WSEE, I noted that the textures for entities were not appearing. Upon checking log files, I noticed that it was because they were not being included in the blocks or items atlas that changed with 1.21.11. 

<img width="996" height="271" alt="image" src="https://github.com/user-attachments/assets/9b9522df-bf57-44f9-8853-11c7351fe71c" />

After noting this, I simply changed the texture location from `worldseed:mobs` to `worldseed:item`, and it was fixed. This now works with both the resource pack template included, and without.

Log Files: https://pastes.dev/wWk56PMSPx

## Before
<img width="1920" height="1009" alt="2025-12-28_10 33 46" src="https://github.com/user-attachments/assets/5fb1b3aa-14ea-4969-80a1-dd03c0952b14" />

## After
<img width="1920" height="1009" alt="2025-12-28_10 38 19" src="https://github.com/user-attachments/assets/25c5aae1-f926-4820-9b18-ccf8fd00f616" />

## Replicating Texture Issue

On current versions of WSEE, you can replicate the texture issue by not using the template resource pack.