### PR TITLE
Add Reposilite publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to Reposilite
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build & publish to Reposilite
+        env:
+          # Reposilite token, injected from repo/org secrets — never committed.
+          # Gradle maps ORG_GRADLE_PROJECT_<name> -> project property <name>,
+          # which the `AtlasEngine` maven repo's PasswordCredentials consume.
+          ORG_GRADLE_PROJECT_AtlasEngineUsername: ${{ secrets.REPOSILITE_USERNAME }}
+          ORG_GRADLE_PROJECT_AtlasEnginePassword: ${{ secrets.REPOSILITE_PASSWORD }}
+        run: ./gradlew publish --no-daemon --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ publishing {
     publications.create<MavenPublication>("maven") {
         groupId = "net.worldseed.multipart"
         artifactId = "WorldSeedEntityEngine"
-        version = "11.5.6"
+        version = "11.6.1"
 
         from(components["java"])
     }


### PR DESCRIPTION
Adds `.github/workflows/publish.yml` — builds with JDK 25 and runs `./gradlew publish` to `reposilite.atlasengine.ca/public` on push to master, with manual dispatch support. Credentials come from the `REPOSILITE_USERNAME` and `REPOSILITE_PASSWORD` secrets. Also commits the already-published version bump from 11.5.6 to 11.6.1.