### PR TITLE
Fix Minecraft 26.2 emote player geometry

### DIFF
--- a/src/test/java/emotes/EmoteExample.java
+++ b/src/test/java/emotes/EmoteExample.java
@@ -17,7 +17,11 @@ public class EmoteExample extends EmotePlayer {
         // playRepeat expects the source animation to opt into wrapping its bone timelines.
         ANIMATIONS = ModelLoader.parseAnimations(ANIMATION_STRING.replace(
                 "\"dab\":{\"animation_length\"",
-                "\"dab\":{\"loop\":true,\"animation_length\""));
+                "\"dab\":{\"loop\":true,\"animation_length\"")
+                .replace("[-47.5,0,-100]", "[-47.5,0,-125]")
+                .replace("[0,0,-100]", "[0,0,-125]")
+                .replace("[0,0,100]", "[0,0,125]")
+                .replace("[-47.5,0,100]", "[-47.5,0,125]"));
     }
 
     public EmoteExample(Instance instance, Pos pos, PlayerSkin skin) {

--- a/src/test/resources/resourcepack_template/assets/minecraft/items/player_head.json
+++ b/src/test/resources/resourcepack_template/assets/minecraft/items/player_head.json
@@ -10,7 +10,8 @@
           "base": "minecraft:custom/entities/player/head",
           "model": {
             "type": "minecraft:player_head"
-          }
+          },
+          "transformation": { "translation": [0.5, 0.0, 0.5], "left_rotation": [1.0, 0.0, 0.0, 0.0], "scale": [1.0, 1.0, 1.0], "right_rotation": [0.0, 0.0, 0.0, 1.0] }
         }
       },
       {
@@ -20,7 +21,8 @@
           "base": "minecraft:custom/entities/player/right_arm",
           "model": {
             "type": "minecraft:player_head"
-          }
+          },
+          "transformation": { "translation": [0.5, 0.0, 0.5], "left_rotation": [1.0, 0.0, 0.0, 0.0], "scale": [1.0, 1.0, 1.0], "right_rotation": [0.0, 0.0, 0.0, 1.0] }
         }
       },
       {
@@ -30,7 +32,8 @@
           "base": "minecraft:custom/entities/player/left_arm",
           "model": {
             "type": "minecraft:player_head"
-          }
+          },
+          "transformation": { "translation": [0.5, 0.0, 0.5], "left_rotation": [1.0, 0.0, 0.0, 0.0], "scale": [1.0, 1.0, 1.0], "right_rotation": [0.0, 0.0, 0.0, 1.0] }
         }
       },
       {
@@ -40,7 +43,8 @@
           "base": "minecraft:custom/entities/player/torso",
           "model": {
             "type": "minecraft:player_head"
-          }
+          },
+          "transformation": { "translation": [0.5, 0.0, 0.5], "left_rotation": [1.0, 0.0, 0.0, 0.0], "scale": [1.0, 1.0, 1.0], "right_rotation": [0.0, 0.0, 0.0, 1.0] }
         }
       },
       {
@@ -50,7 +54,8 @@
           "base": "minecraft:custom/entities/player/right_leg",
           "model": {
             "type": "minecraft:player_head"
-          }
+          },
+          "transformation": { "translation": [0.5, 0.0, 0.5], "left_rotation": [1.0, 0.0, 0.0, 0.0], "scale": [1.0, 1.0, 1.0], "right_rotation": [0.0, 0.0, 0.0, 1.0] }
         }
       },
       {
@@ -60,7 +65,8 @@
           "base": "minecraft:custom/entities/player/left_leg",
           "model": {
             "type": "minecraft:player_head"
-          }
+          },
+          "transformation": { "translation": [0.5, 0.0, 0.5], "left_rotation": [1.0, 0.0, 0.0, 0.0], "scale": [1.0, 1.0, 1.0], "right_rotation": [0.0, 0.0, 0.0, 1.0] }
         }
       },
       {
@@ -70,7 +76,8 @@
           "base": "minecraft:custom/entities/player/slim_right",
           "model": {
             "type": "minecraft:player_head"
-          }
+          },
+          "transformation": { "translation": [0.5, 0.0, 0.5], "left_rotation": [1.0, 0.0, 0.0, 0.0], "scale": [1.0, 1.0, 1.0], "right_rotation": [0.0, 0.0, 0.0, 1.0] }
         }
       },
       {
@@ -80,7 +87,8 @@
           "base": "minecraft:custom/entities/player/slim_left",
           "model": {
             "type": "minecraft:player_head"
-          }
+          },
+          "transformation": { "translation": [0.5, 0.0, 0.5], "left_rotation": [1.0, 0.0, 0.0, 0.0], "scale": [1.0, 1.0, 1.0], "right_rotation": [0.0, 0.0, 0.0, 1.0] }
         }
       }
     ]


### PR DESCRIPTION
Corrects the final Minecraft 26.2 emote compatibility issue after #73.

- Applies the complete vanilla 26.2 special-model transformation to every player-head body-part model, keeping the skull mesh centered on its animation pivot.
- Raises the dab arm angles from 100° to 125° so the pose reads correctly while shoulders remain attached.
- Removes all temporary test automation from the demo.

Validation:
- Automated Fabric 26.2 client loaded the generated resource pack without item-model or shader errors.
- Captured consecutive frames show an assembled player silhouette with attached head, torso, arms, and legs throughout the dab loop.
- `./gradlew clean test build javadoc` and the final `./gradlew test` pass.