### PR TITLE
Fix Blockbench animation coordinate parity

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ publishing {
     publications.create<MavenPublication>("maven") {
         groupId = "net.worldseed.multipart"
         artifactId = "WorldSeedEntityEngine"
-        version = "12.0.0"
+        version = "12.0.1"
 
         from(components["java"])
     }

--- a/src/main/java/net/worldseed/multipart/animations/Interpolator.java
+++ b/src/main/java/net/worldseed/multipart/animations/Interpolator.java
@@ -55,7 +55,7 @@ public class Interpolator {
         if ("step".equals(a.lerp())) return start;                  // hold the leaving value until next keyframe
 
         Vec end = pre(transform, times.get(i + 1), time);           // value approaching keyframe i+1
-        if (isSmooth(a.lerp()) || isSmooth(b.lerp())) {             // catmullrom or bezier -> smooth spline
+        if (isSmooth(a.lerp()) || isSmooth(b.lerp())) {
             Vec before = post(transform, times.get(Math.max(0, i - 1)), time);
             Vec after = pre(transform, times.get(Math.min(n - 1, i + 2)), time);
             return catmullRom(before, start, end, after, alpha);
@@ -64,8 +64,7 @@ public class Interpolator {
     }
 
     private static boolean isSmooth(String lerp) {
-        // bezier is approximated as a Catmull-Rom smooth spline (its custom handles aren't exported)
-        return "catmullrom".equals(lerp) || "bezier".equals(lerp);
+        return "catmullrom".equals(lerp);
     }
 
     // value approaching a keyframe (its primary / "pre" data point)

--- a/src/main/java/net/worldseed/resourcepack/multipart/generator/AnimationGenerator.java
+++ b/src/main/java/net/worldseed/resourcepack/multipart/generator/AnimationGenerator.java
@@ -8,6 +8,16 @@ import java.util.Map;
 
 public class AnimationGenerator {
     public static JsonObject generate(JsonArray animationRaw) {
+        return generate(animationRaw, true);
+    }
+
+    /**
+     * Convert Blockbench animations to the runtime animation format.
+     *
+     * @param legacyCoordinates {@code true} for pre-5.0 bbmodels, whose animation values use the
+     *                          legacy Bedrock coordinate convention
+     */
+    public static JsonObject generate(JsonArray animationRaw, boolean legacyCoordinates) {
         JsonObjectBuilder animations = Json.createObjectBuilder();
         if (animationRaw == null) return animations.build();
 
@@ -77,7 +87,7 @@ public class AnimationGenerator {
                     String interpolation = keyframe.getString("interpolation", "linear");
 
                     JsonObject built = Json.createObjectBuilder()
-                            .add("post", dataPoints)
+                            .add("post", legacyCoordinates ? dataPoints : mirrorForRuntime(dataPoints, channel))
                             .add("lerp_mode", interpolation)
                             .build();
 
@@ -128,5 +138,34 @@ public class AnimationGenerator {
         }
 
         return animations.build();
+    }
+
+    private static JsonArray mirrorForRuntime(JsonArray points, String channel) {
+        boolean mirrorX = channel.equals("rotation") || channel.equals("position");
+        boolean mirrorY = channel.equals("rotation");
+        if (!mirrorX && !mirrorY) return points;
+
+        JsonArrayBuilder result = Json.createArrayBuilder();
+        for (JsonValue value : points) {
+            if (!(value instanceof JsonObject point)) {
+                result.add(value);
+                continue;
+            }
+            JsonObjectBuilder mirrored = Json.createObjectBuilder(point);
+            if (mirrorX && point.containsKey("x")) mirrored.add("x", negate(point.get("x")));
+            if (mirrorY && point.containsKey("y")) mirrored.add("y", negate(point.get("y")));
+            result.add(mirrored);
+        }
+        return result.build();
+    }
+
+    private static JsonValue negate(JsonValue value) {
+        if (value instanceof JsonNumber number) {
+            return Json.createValue(-number.doubleValue());
+        }
+        if (value instanceof JsonString string) {
+            return Json.createValue("-(" + string.getString() + ")");
+        }
+        return value;
     }
 }

--- a/src/main/java/net/worldseed/resourcepack/multipart/generator/ModelGenerator.java
+++ b/src/main/java/net/worldseed/resourcepack/multipart/generator/ModelGenerator.java
@@ -14,7 +14,10 @@ public class ModelGenerator {
     public static BBEntityModel generate(PackBuilder.Model modelObj) {
         JsonObject model = Json.createReader(new StringReader(modelObj.data())).readObject();
 
-        JsonObject animations = AnimationGenerator.generate(model.getJsonArray("animations"));
+        JsonObject meta = model.getJsonObject("meta");
+        String formatVersion = meta == null ? "" : meta.getString("format_version", "");
+        JsonObject animations = AnimationGenerator.generate(
+                model.getJsonArray("animations"), usesLegacyAnimationCoordinates(formatVersion));
 
         int width = 16;
         int height = 16;
@@ -64,5 +67,14 @@ public class ModelGenerator {
     public record BBEntityModel(JsonObject geo, JsonObject animations,
                                 Map<String, TextureGenerator.TextureData> textures, String id,
                                 AdditionalStates additionalStates) {
+    }
+
+    static boolean usesLegacyAnimationCoordinates(String formatVersion) {
+        try {
+            String major = formatVersion.split("\\.", 2)[0];
+            return Integer.parseInt(major) < 5;
+        } catch (NumberFormatException ignored) {
+            return false;
+        }
     }
 }

--- a/src/test/java/net/worldseed/multipart/animations/InterpolatorTest.java
+++ b/src/test/java/net/worldseed/multipart/animations/InterpolatorTest.java
@@ -58,9 +58,8 @@ class InterpolatorTest {
     }
 
     @Test
-    void bezierInterpolatesAsSmoothSpline() {
-        // bezier is approximated as Catmull-Rom, so it matches the smooth-spline midpoint (5.0), not linear
-        var t = map(0.0, kf(0, "bezier"), 1.0, kf(0, "bezier"), 2.0, kf(10, "bezier"), 3.0, kf(10, "bezier"));
+    void bezierFallsBackToLinearWithoutExportedHandles() {
+        var t = map(0.0, kf(0, "bezier"), 1.0, kf(0, "bezier"), 2.0, kf(10, "bezier"), 3.0, kf(20, "bezier"));
         assertEquals(5.0, Interpolator.interpolateTranslation(1.5, t, 3.0).x(), 1e-9);
     }
 

--- a/src/test/java/net/worldseed/resourcepack/multipart/generator/AnimationRendererParityTest.java
+++ b/src/test/java/net/worldseed/resourcepack/multipart/generator/AnimationRendererParityTest.java
@@ -1,0 +1,88 @@
+package net.worldseed.resourcepack.multipart.generator;
+
+import org.junit.jupiter.api.Test;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AnimationRendererParityTest {
+    @Test
+    void detectsTheSameLegacyVersionsAsTheRustRenderer() {
+        assertTrue(ModelGenerator.usesLegacyAnimationCoordinates("4.10"));
+        assertFalse(ModelGenerator.usesLegacyAnimationCoordinates("5.0"));
+        assertFalse(ModelGenerator.usesLegacyAnimationCoordinates(""));
+    }
+
+    @Test
+    void modernCoordinatesCancelTheRuntimeLegacyMirror() {
+        JsonObject animation = animationWithPoints(
+                Json.createObjectBuilder().add("x", 10).add("y", 20).add("z", 30).build(),
+                Json.createObjectBuilder().add("x", "query.anim_time * 2").add("y", 2).add("z", 3).build());
+
+        JsonObject generated = AnimationGenerator.generate(
+                Json.createArrayBuilder().add(animation).build(), false);
+        JsonObject rotation = point(generated, "rotation");
+        JsonObject position = point(generated, "position");
+
+        assertEquals(-10, rotation.getInt("x"));
+        assertEquals(-20, rotation.getInt("y"));
+        assertEquals(30, rotation.getInt("z"));
+        assertEquals("-(query.anim_time * 2)", position.getString("x"));
+        assertEquals(2, position.getInt("y"));
+        assertEquals(3, position.getInt("z"));
+    }
+
+    @Test
+    void legacyCoordinatesPassThroughForTheRuntimeMirror() {
+        JsonObject animation = animationWithPoints(
+                Json.createObjectBuilder().add("x", 10).add("y", 20).add("z", 30).build(),
+                Json.createObjectBuilder().add("x", 1).add("y", 2).add("z", 3).build());
+
+        JsonObject generated = AnimationGenerator.generate(
+                Json.createArrayBuilder().add(animation).build(), true);
+
+        assertEquals(10, point(generated, "rotation").getInt("x"));
+        assertEquals(1, point(generated, "position").getInt("x"));
+    }
+
+    private static JsonObject animationWithPoints(JsonObject rotation, JsonObject position) {
+        JsonArray keyframes = Json.createArrayBuilder()
+                .add(keyframe("rotation", rotation))
+                .add(keyframe("position", position))
+                .build();
+        JsonObject animator = Json.createObjectBuilder()
+                .add("name", "arm")
+                .add("type", "bone")
+                .add("keyframes", keyframes)
+                .build();
+        return Json.createObjectBuilder()
+                .add("name", "wave")
+                .add("length", 1)
+                .add("animators", Json.createObjectBuilder().add("uuid", animator))
+                .build();
+    }
+
+    private static JsonObject keyframe(String channel, JsonObject point) {
+        return Json.createObjectBuilder()
+                .add("channel", channel)
+                .add("time", 0)
+                .add("interpolation", "linear")
+                .add("data_points", Json.createArrayBuilder().add(point))
+                .build();
+    }
+
+    private static JsonObject point(JsonObject generated, String channel) {
+        return generated.getJsonObject("wave")
+                .getJsonObject("bones")
+                .getJsonObject("arm")
+                .getJsonObject(channel)
+                .getJsonObject("0.0")
+                .getJsonArray("post")
+                .getJsonObject(0);
+    }
+}


### PR DESCRIPTION
Fix animation output parity with the Rust renderer.

- Respect the Blockbench 5.0 coordinate-format boundary
- Preserve legacy pre-5.0 animation mirroring
- Match the renderer's linear fallback for Bezier keyframes without handles
- Add regression coverage for numeric and Molang animation values

Release version: 12.0.1