### PR TITLE
Add Minestom-compatible player avatars and held items

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ repositories {
 Add the library as a dependency
 ```
 dependencies {
-    implementation("net.worldseed.multipart:WorldSeedEntityEngine:<version>")
+    implementation("net.worldseed.multipart:WorldSeedEntityEngine:13.0.0")
 }
 ```
 
@@ -83,6 +83,39 @@ Add the following VM arguments to your run configuration
 ```
 
 This is required for the molang compiler library.
+
+### Transparent player entities
+
+`EmotePlayer` is a WSEE model with an invisible Minestom entity as its carrier. It can be moved,
+rotated, viewed, and equipped through the normal Minestom entity APIs while rendering as a player
+skin. Vanilla idle, walking, looking, and hand-swing animations are applied automatically.
+
+```java
+PlayerSkin skin = new PlayerSkin(textureValue, textureSignature);
+EmotePlayer actor = new EmotePlayer(instance, new Pos(0, 42, 0), skin);
+
+actor.addViewer(player);
+actor.setVelocity(new Vec(0.1, 0, 0));
+actor.setItemInMainHand(ItemStack.of(Material.DIAMOND_SWORD));
+actor.setItemInOffHand(ItemStack.of(Material.SHIELD));
+actor.swingMainHand();
+```
+
+The standard `setItemInMainHand`, `setItemInOffHand`, `getItemInMainHand`, and
+`getItemInOffHand` methods control the visible held items. `ItemStack.AIR` clears a hand. Items
+remain attached to their arm through idle, walking, attack, and loaded emote animations.
+
+Blockbench animations can be loaded and played through the WSEE animation interface:
+
+```java
+actor.loadEmotes(emotes);
+actor.getAnimationHandler().playOnce("wave", () -> {});
+actor.getAnimationHandler().playRepeat("dance");
+```
+
+Use `actor.setVanillaAnimationsEnabled(false)` when a custom animation should have complete
+control over the player bones, and re-enable it to return to the automatic vanilla pose system.
+Removing the `EmotePlayer` also removes its model bones and held-item displays.
 
 ## Restrictions
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ publishing {
     publications.create<MavenPublication>("maven") {
         groupId = "net.worldseed.multipart"
         artifactId = "WorldSeedEntityEngine"
-        version = "12.0.1"
+        version = "13.0.0"
 
         from(components["java"])
     }

--- a/src/main/java/net/worldseed/gestures/EmoteModel.java
+++ b/src/main/java/net/worldseed/gestures/EmoteModel.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.StringReader;
 import java.util.Map;
+import java.util.HashMap;
 
 public class EmoteModel extends GenericModelImpl {
     protected static final Gson GSON = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
@@ -39,11 +40,11 @@ public class EmoteModel extends GenericModelImpl {
 
     private static final Map<String, Point> BONE_OFFSETS = Map.ofEntries(
             Map.entry("Head", new Vec(0, 0, 0)),
-            Map.entry("RightArm", new Vec(1.17, 0, 0)),
-            Map.entry("LeftArm", new Vec(-1.17, 0, 0)),
+            Map.entry("RightArm", new Vec(75.0 / 64.0, 0, 0)),
+            Map.entry("LeftArm", new Vec(-75.0 / 64.0, 0, 0)),
             Map.entry("Body", new Vec(0, 0, 0)),
-            Map.entry("RightLeg", new Vec(0.4446, 0, 0)),
-            Map.entry("LeftLeg", new Vec(-0.4446, 0, 0))
+            Map.entry("RightLeg", new Vec(57.0 / 128.0, 0, 0)),
+            Map.entry("LeftLeg", new Vec(-57.0 / 128.0, 0, 0))
     );
 
     private static final Map<String, Double> VERTICAL_OFFSETS = Map.of(
@@ -74,6 +75,8 @@ public class EmoteModel extends GenericModelImpl {
     }
 
     private final PlayerSkin skin;
+    private final Map<String, ProceduralBoneAnimation> vanillaRotations = new HashMap<>();
+    private final Map<String, ProceduralBoneAnimation> vanillaTranslations = new HashMap<>();
 
     public EmoteModel(PlayerSkin skin) {
         this.skin = skin;
@@ -113,6 +116,18 @@ public class EmoteModel extends GenericModelImpl {
             e.printStackTrace();
         }
 
+        for (String boneName : BONE_OFFSETS.keySet()) {
+            ModelBone bone = this.parts.get(boneName);
+            if (bone instanceof ModelBoneImpl impl) {
+                ProceduralBoneAnimation animation = new ProceduralBoneAnimation(boneName, net.worldseed.multipart.ModelLoader.AnimationType.ROTATION);
+                impl.addAnimation(animation);
+                vanillaRotations.put(boneName, animation);
+                ProceduralBoneAnimation translation = new ProceduralBoneAnimation(boneName, net.worldseed.multipart.ModelLoader.AnimationType.TRANSLATION);
+                impl.addAnimation(translation);
+                vanillaTranslations.put(boneName, translation);
+            }
+        }
+
         for (ModelBone modelBonePart : this.parts.values()) {
             if (modelBonePart instanceof ModelBoneViewable)
                 viewableBones.add((ModelBoneImpl) modelBonePart);
@@ -137,6 +152,19 @@ public class EmoteModel extends GenericModelImpl {
 
     public void setOffHandItem(@NotNull ItemStack item) {
         arm("LeftArm").setHeldItem(item);
+    }
+
+    void applyVanillaPose(VanillaPlayerAnimationState state) {
+        VanillaPlayerPose.Pose pose = VanillaPlayerPose.pose(state);
+        pose.rotations().forEach((bone, rotation) -> {
+            ProceduralBoneAnimation animation = vanillaRotations.get(bone);
+            if (animation != null) animation.setTransform(rotation);
+        });
+        pose.translations().forEach((bone, translation) -> {
+            ProceduralBoneAnimation animation = vanillaTranslations.get(bone);
+            if (animation != null) animation.setTransform(translation);
+        });
+        draw();
     }
 
     public @NotNull ItemStack getOffHandItem() {

--- a/src/main/java/net/worldseed/gestures/EmoteModel.java
+++ b/src/main/java/net/worldseed/gestures/EmoteModel.java
@@ -9,6 +9,7 @@ import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.PlayerSkin;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.item.ItemStack;
 import net.worldseed.multipart.GenericModelImpl;
 import net.worldseed.multipart.model_bones.ModelBone;
 import net.worldseed.multipart.model_bones.ModelBoneImpl;
@@ -124,6 +125,28 @@ public class EmoteModel extends GenericModelImpl {
 
     public void init(@Nullable Instance instance, @NotNull Pos position) {
         this.init_(instance, position);
+    }
+
+    public void setMainHandItem(@NotNull ItemStack item) {
+        arm("RightArm").setHeldItem(item);
+    }
+
+    public @NotNull ItemStack getMainHandItem() {
+        return arm("RightArm").getHeldItem();
+    }
+
+    public void setOffHandItem(@NotNull ItemStack item) {
+        arm("LeftArm").setHeldItem(item);
+    }
+
+    public @NotNull ItemStack getOffHandItem() {
+        return arm("LeftArm").getHeldItem();
+    }
+
+    private ModelBoneEmote arm(String name) {
+        ModelBone bone = this.parts.get(name);
+        if (bone instanceof ModelBoneEmote emoteBone) return emoteBone;
+        throw new IllegalStateException("Emote model is not initialized: missing " + name);
     }
 
     @Override

--- a/src/main/java/net/worldseed/gestures/EmotePlayer.java
+++ b/src/main/java/net/worldseed/gestures/EmotePlayer.java
@@ -8,6 +8,7 @@ import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.entity.EntityDamageEvent;
 import net.minestom.server.event.player.PlayerEntityInteractEvent;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.item.ItemStack;
 import net.worldseed.multipart.animations.AnimationHandler;
 import net.worldseed.multipart.animations.AnimationHandlerImpl;
 import org.jetbrains.annotations.NotNull;
@@ -85,6 +86,42 @@ public abstract class EmotePlayer extends EntityCreature {
 
     public void setRotation(float yaw) {
         this.model.setGlobalRotation(yaw);
+    }
+
+    /**
+     * Set the item rendered in this emote player's right (main) hand. The item follows all
+     * translations and rotations applied to the right arm.
+     *
+     * @param item item to render, or {@link ItemStack#AIR} to clear the hand
+     */
+    public void setMainHandItem(@NotNull ItemStack item) {
+        this.model.setMainHandItem(item);
+    }
+
+    /** @return the item currently rendered in the right (main) hand */
+    public @NotNull ItemStack getMainHandItem() {
+        return this.model.getMainHandItem();
+    }
+
+    /**
+     * Set the item rendered in this emote player's left (off) hand. The item follows all
+     * translations and rotations applied to the left arm.
+     *
+     * @param item item to render, or {@link ItemStack#AIR} to clear the hand
+     */
+    public void setOffHandItem(@NotNull ItemStack item) {
+        this.model.setOffHandItem(item);
+    }
+
+    /** @return the item currently rendered in the left (off) hand */
+    public @NotNull ItemStack getOffHandItem() {
+        return this.model.getOffHandItem();
+    }
+
+    /** Clear both rendered hand items. */
+    public void clearHandItems() {
+        this.model.setMainHandItem(ItemStack.AIR);
+        this.model.setOffHandItem(ItemStack.AIR);
     }
 
     @Override

--- a/src/main/java/net/worldseed/gestures/EmotePlayer.java
+++ b/src/main/java/net/worldseed/gestures/EmotePlayer.java
@@ -11,34 +11,40 @@ import net.minestom.server.instance.Instance;
 import net.minestom.server.item.ItemStack;
 import net.worldseed.multipart.animations.AnimationHandler;
 import net.worldseed.multipart.animations.AnimationHandlerImpl;
+import net.worldseed.multipart.ModelEntity;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
+import java.util.EnumMap;
 
-public abstract class EmotePlayer extends EntityCreature {
+/**
+ * A transparent Minestom living entity backed by WSEE's vanilla player model.
+ *
+ * <p>Use ordinary Minestom entity APIs for movement, facing and equipment. In
+ * particular, {@link #setItemInMainHand(ItemStack)} and
+ * {@link #setItemInOffHand(ItemStack)} update the rendered hands without exposing
+ * equipment on the invisible carrier. WSEE-specific animations remain available
+ * through {@link #getAnimationHandler()} and {@link #getModel()}.</p>
+ */
+public class EmotePlayer extends ModelEntity {
 
     private final EmoteModel model;
     private final AnimationHandler animationHandler;
     private int emoteIndex = 0;
+    private final VanillaPlayerAnimationState vanillaAnimationState = new VanillaPlayerAnimationState();
+    private boolean vanillaAnimationsEnabled = true;
+    private final Map<EquipmentSlot, ItemStack> visualEquipment = new EnumMap<>(EquipmentSlot.class);
 
     public EmotePlayer(Instance instance, Pos pos, PlayerSkin skin, EntityType entityType) {
-        super(entityType);
+        this(new EmoteModel(skin), instance, pos, entityType);
+    }
 
-        Entity self = this;
-        this.model = new EmoteModel(skin) {
-            @Override
-            public void setPosition(Pos pos) {
-                super.setPosition(pos);
-                if (self.getInstance() != null) self.teleport(pos);
-            }
-        };
-
-        model.init(instance, pos);
+    private EmotePlayer(EmoteModel model, Instance instance, Pos pos, EntityType entityType) {
+        super(entityType, model, instance, pos);
+        this.model = model;
 
         setBoundingBox(0.8, 1.8, 0.8);
-        this.setInvisible(true);
-        this.getAttribute(Attribute.MOVEMENT_SPEED).setBaseValue(0.001f);
-        this.setInstance(instance, pos).join();
+        this.getAttribute(Attribute.MOVEMENT_SPEED).setBaseValue(0.1f);
 
         this.animationHandler = new AnimationHandlerImpl(model) {
             @Override
@@ -70,22 +76,81 @@ public abstract class EmotePlayer extends EntityCreature {
     }
 
     @Override
-    public void remove() {
-        this.model.destroy();
-        this.animationHandler.destroy();
-        super.remove();
-    }
-
-    @Override
     public void tick(long time) {
         var position = this.getPosition();
         super.tick(time);
-        if (position.equals(this.getPosition())) return;
-        this.model.setPosition(this.getPosition());
+        if (isRemoved()) return;
+        var newPosition = this.getPosition();
+        model.setGlobalRotation(newPosition.yaw(), newPosition.pitch());
+        if (vanillaAnimationsEnabled) {
+            vanillaAnimationState.setAgeInTicks(vanillaAnimationState.ageInTicks() + 1);
+            vanillaAnimationState.setHeadYaw(0);
+            vanillaAnimationState.setHeadPitch(newPosition.pitch());
+            // Minecraft 26.2 LivingEntity#updateWalkAnimation / WalkAnimationState#update:
+            // measure this tick's horizontal displacement, smooth toward it by 0.4,
+            // then advance the phase by the smoothed speed.
+            float targetSpeed = (float) Math.min(1.0,
+                    Math.hypot(newPosition.x() - position.x(), newPosition.z() - position.z()) * 4.0);
+            float walkSpeed = vanillaAnimationState.walkAnimationSpeed();
+            walkSpeed += (targetSpeed - walkSpeed) * 0.4f;
+            vanillaAnimationState.setWalkAnimationSpeed(walkSpeed);
+            vanillaAnimationState.setWalkAnimationPos(vanillaAnimationState.walkAnimationPos() + walkSpeed);
+            if (vanillaAnimationState.attackTime() > 0) {
+                vanillaAnimationState.setAttackTime(Math.max(0, vanillaAnimationState.attackTime() - 0.1f));
+            }
+            model.applyVanillaPose(vanillaAnimationState);
+        }
+    }
+
+    public VanillaPlayerAnimationState vanillaAnimationState() {
+        return vanillaAnimationState;
+    }
+
+    public void setVanillaAnimationsEnabled(boolean enabled) {
+        this.vanillaAnimationsEnabled = enabled;
+        if (enabled) model.applyVanillaPose(vanillaAnimationState);
+    }
+
+    public boolean vanillaAnimationsEnabled() {
+        return vanillaAnimationsEnabled;
+    }
+
+    /** Apply the current vanilla animation inputs immediately without advancing their clock. */
+    public void applyVanillaAnimationState() {
+        model.applyVanillaPose(vanillaAnimationState);
+    }
+
+    public void swingMainHand() {
+        super.swingMainHand();
+        vanillaAnimationState.setAttackArm(VanillaPlayerAnimationState.AttackArm.RIGHT);
+        vanillaAnimationState.setAttackTime(1.0f);
+    }
+
+    @Override
+    public void swingOffHand() {
+        super.swingOffHand();
+        vanillaAnimationState.setAttackArm(VanillaPlayerAnimationState.AttackArm.LEFT);
+        vanillaAnimationState.setAttackTime(1.0f);
+    }
+
+    @Override
+    public void swingMainHand(boolean sendPacketToSelf) {
+        super.swingMainHand(sendPacketToSelf);
+        vanillaAnimationState.setAttackArm(VanillaPlayerAnimationState.AttackArm.RIGHT);
+        vanillaAnimationState.setAttackTime(1.0f);
+    }
+
+    @Override
+    public void swingOffHand(boolean sendPacketToSelf) {
+        super.swingOffHand(sendPacketToSelf);
+        vanillaAnimationState.setAttackArm(VanillaPlayerAnimationState.AttackArm.LEFT);
+        vanillaAnimationState.setAttackTime(1.0f);
     }
 
     public void setRotation(float yaw) {
-        this.model.setGlobalRotation(yaw);
+        Pos position = getPosition().withYaw(yaw);
+        teleport(position);
+        model.setGlobalRotation(yaw, position.pitch());
     }
 
     /**
@@ -95,12 +160,12 @@ public abstract class EmotePlayer extends EntityCreature {
      * @param item item to render, or {@link ItemStack#AIR} to clear the hand
      */
     public void setMainHandItem(@NotNull ItemStack item) {
-        this.model.setMainHandItem(item);
+        setItemInMainHand(item);
     }
 
     /** @return the item currently rendered in the right (main) hand */
     public @NotNull ItemStack getMainHandItem() {
-        return this.model.getMainHandItem();
+        return getItemInMainHand();
     }
 
     /**
@@ -110,34 +175,59 @@ public abstract class EmotePlayer extends EntityCreature {
      * @param item item to render, or {@link ItemStack#AIR} to clear the hand
      */
     public void setOffHandItem(@NotNull ItemStack item) {
-        this.model.setOffHandItem(item);
+        setItemInOffHand(item);
     }
 
     /** @return the item currently rendered in the left (off) hand */
     public @NotNull ItemStack getOffHandItem() {
-        return this.model.getOffHandItem();
+        return getItemInOffHand();
     }
 
     /** Clear both rendered hand items. */
     public void clearHandItems() {
-        this.model.setMainHandItem(ItemStack.AIR);
-        this.model.setOffHandItem(ItemStack.AIR);
+        setMainHandItem(ItemStack.AIR);
+        setOffHandItem(ItemStack.AIR);
     }
 
     @Override
-    public void updateNewViewer(@NotNull Player player) {
-        super.updateNewViewer(player);
-        this.model.addViewer(player);
+    public @NotNull ItemStack getEquipment(@NotNull EquipmentSlot slot) {
+        return visualEquipment.getOrDefault(slot, ItemStack.AIR);
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     @Override
-    public void updateOldViewer(@NotNull Player player) {
-        super.updateOldViewer(player);
-        this.model.removeViewer(player);
+    public void setEquipment(@NotNull EquipmentSlot slot, @NotNull ItemStack item) {
+        if (item.equals(ItemStack.AIR)) visualEquipment.remove(slot);
+        else visualEquipment.put(slot, item);
+        switch (slot) {
+            case MAIN_HAND -> {
+                model.setMainHandItem(item);
+                vanillaAnimationState.setRightArmPose(item.equals(ItemStack.AIR)
+                        ? VanillaPlayerAnimationState.ArmPose.EMPTY
+                        : VanillaPlayerAnimationState.ArmPose.ITEM);
+            }
+            case OFF_HAND -> {
+                model.setOffHandItem(item);
+                vanillaAnimationState.setLeftArmPose(item.equals(ItemStack.AIR)
+                        ? VanillaPlayerAnimationState.ArmPose.EMPTY
+                        : VanillaPlayerAnimationState.ArmPose.ITEM);
+            }
+            default -> { }
+        }
+        model.applyVanillaPose(vanillaAnimationState);
     }
 
-    protected AnimationHandler getAnimationHandler() {
+    @Override
+    public @NotNull EmoteModel getModel() {
+        return model;
+    }
+
+    public @NotNull AnimationHandler getAnimationHandler() {
         return animationHandler;
+    }
+
+    @Override
+    public void remove() {
+        animationHandler.destroy();
+        super.remove();
     }
 }

--- a/src/main/java/net/worldseed/gestures/ModelBoneEmote.java
+++ b/src/main/java/net/worldseed/gestures/ModelBoneEmote.java
@@ -28,10 +28,16 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
     private static final Quaternion RIGHT_HAND_ROTATION = new Quaternion(new Vec(-90, 0, 0));
     private static final Quaternion LEFT_HAND_ROTATION = RIGHT_HAND_ROTATION;
     private static final double PLAYER_RENDER_SCALE = 15.0 / 16.0;
+    private static final double HAND_PIVOT_Y_OFFSET = -0.11;
+    // Generated arm-display origin to ItemInHandLayer hand origin. This is the
+    // root-local residual after the pack's 15/16 scale and display-model centering.
+    private static final double HAND_DISPLAY_DEPTH_CORRECTION = 0.585033;
+    private static final double ITEM_POSE_ARM_X = -18.0;
+    private static final double ARM_HAND_LEVER = 1.0546875;
     private static final Point RIGHT_HAND_GRIP = new Vec(
-            PLAYER_RENDER_SCALE / 16.0, -PLAYER_RENDER_SCALE * 10.0 / 16.0, -PLAYER_RENDER_SCALE * 2.0 / 16.0);
+            PLAYER_RENDER_SCALE / 16.0, -PLAYER_RENDER_SCALE * 10.0 / 16.0, PLAYER_RENDER_SCALE * 2.0 / 16.0);
     private static final Point LEFT_HAND_GRIP = new Vec(
-            -PLAYER_RENDER_SCALE / 16.0, -PLAYER_RENDER_SCALE * 10.0 / 16.0, -PLAYER_RENDER_SCALE * 2.0 / 16.0);
+            -PLAYER_RENDER_SCALE / 16.0, -PLAYER_RENDER_SCALE * 10.0 / 16.0, PLAYER_RENDER_SCALE * 2.0 / 16.0);
     private final Double verticalOffset;
     private final BoneEntity heldItemStand;
     private final Point heldItemGrip;
@@ -46,12 +52,14 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
         boolean leftArm = name.equals("LeftArm");
         this.heldItemGrip = rightArm ? RIGHT_HAND_GRIP : leftArm ? LEFT_HAND_GRIP : null;
         this.heldItemRotation = rightArm ? RIGHT_HAND_ROTATION : leftArm ? LEFT_HAND_ROTATION : null;
+        // Bone display origins are moved outward to centre their generated head-item
+        // cubes. Vanilla's hand pivot is still at the shoulder ModelPart origin.
         if (rightArm || leftArm) {
             this.heldItemStand = new BoneEntity(EntityType.ITEM_DISPLAY, model, name + "HeldItem");
             this.heldItemStand.editEntityMeta(ItemDisplayMeta.class, meta -> {
                 meta.setViewRange(10000);
-                meta.setTransformationInterpolationDuration(2);
-                meta.setPosRotInterpolationDuration(2);
+                meta.setTransformationInterpolationDuration(1);
+                meta.setPosRotInterpolationDuration(1);
                 meta.setScale(new Vec(PLAYER_RENDER_SCALE));
                 meta.setDisplayContext(rightArm
                         ? ItemDisplayMeta.DisplayContext.THIRDPERSON_RIGHT_HAND
@@ -70,8 +78,8 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
             this.stand = new BoneEntity(EntityType.ITEM_DISPLAY, model, name);
             this.stand.editEntityMeta(ItemDisplayMeta.class, meta -> {
                 meta.setViewRange(10000);
-                meta.setTransformationInterpolationDuration(2);
-                meta.setPosRotInterpolationDuration(2);
+                meta.setTransformationInterpolationDuration(1);
+                meta.setPosRotInterpolationDuration(1);
                 meta.setTranslation(new Vec(0, translation, 0));
                 meta.setDisplayContext(ItemDisplayMeta.DisplayContext.THIRDPERSON_RIGHT_HAND);
 
@@ -116,11 +124,17 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
             var position = calculatePosition();
 
             if (this.stand.getEntityMeta() instanceof ItemDisplayMeta meta) {
-                Quaternion q = new Quaternion(calculateRotation());
+                Quaternion q = calculateVisibleRotation();
 
                 meta.setNotifyAboutChanges(false);
                 meta.setTransformationInterpolationStartDelta(0);
-                meta.setScale(new Vec(scale.x() * this.scale, scale.y() * this.scale, scale.z() * this.scale));
+                // The generated player bone models already include vanilla's 15/16
+                // entity render scale. Applying it again here shrinks every bone about
+                // its own centre, opening visible seams between otherwise adjacent parts.
+                meta.setScale(new Vec(
+                        scale.x() * this.scale,
+                        scale.y() * this.scale,
+                        scale.z() * this.scale));
                 meta.setRightRotation(new float[]{(float) q.x(), (float) q.y(), (float) q.z(), (float) q.w()});
                 meta.setNotifyAboutChanges(true);
 
@@ -129,13 +143,14 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
         }
 
         if (this.heldItemStand != null && this.heldItemStand.getEntityMeta() instanceof ItemDisplayMeta meta) {
-            Quaternion q = new Quaternion(calculateRotation());
+            Quaternion q = calculateHeldItemRotation();
             meta.setNotifyAboutChanges(false);
             meta.setTransformationInterpolationStartDelta(0);
             meta.setTranslation(calculateHeldItemTranslation());
             meta.setLeftRotation(new float[]{(float) q.x(), (float) q.y(), (float) q.z(), (float) q.w()});
             meta.setNotifyAboutChanges(true);
-            this.heldItemStand.teleport(calculateHeldItemPosition().withView(0, 0));
+            float yaw = (float) ((this.model.getGlobalRotation() + 360) % 360);
+            this.heldItemStand.teleport(calculateHeldItemPosition().withView(yaw, 0));
         }
     }
 
@@ -145,12 +160,41 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
     }
 
     private Pos calculateHeldItemPosition() {
-        return calculatePosition();
+        // The arm display is centred around the generated head-item model's origin.
+        // Vanilla's ModelPart hand pivot is 0.11 blocks below that display origin.
+        Quaternion entityFacing = new Quaternion(new Vec(0, -this.model.getGlobalRotation(), 0));
+        double armXDelta = Math.toRadians(getPropagatedRotation().x() - ITEM_POSE_ARM_X);
+        // The generated arm display and vanilla's hand matrix use different origins.
+        // When the arm bobs around X, that origin separation becomes a depth arc.
+        // Keep the correction in entity-local space so both arms and every yaw share
+        // the same pivot equation instead of accumulating an animation-phase offset.
+        double animatedPivotDepth = -ARM_HAND_LEVER * Math.sin(armXDelta);
+        Point duplicateDisplayDepth = rotate(
+                new Vec(0, 0, (HAND_DISPLAY_DEPTH_CORRECTION + animatedPivotDepth) * scale), entityFacing);
+        return calculatePosition().add(duplicateDisplayDepth).add(0, HAND_PIVOT_Y_OFFSET * scale, 0);
     }
 
     private Point calculateHeldItemTranslation() {
-        Quaternion rotation = new Quaternion(calculateRotation());
-        return rotate(heldItemGrip.mul(scale), rotation);
+        return rotate(heldItemGrip.mul(scale), calculateHeldItemGripRotation());
+    }
+
+    private Quaternion calculateHeldItemGripRotation() {
+        Quaternion local = calculateFinalAngle(new Quaternion(getPropagatedRotation()));
+        return new Quaternion(new Vec(0, 180, 0)).multiply(local);
+    }
+
+    private Quaternion calculateHeldItemRotation() {
+        Quaternion local = calculateFinalAngle(new Quaternion(getPropagatedRotation()));
+        // DisplayRenderer applies the entity yaw as R_y(-yaw). Vanilla's player root
+        // is R_y(180-yaw), so metadata must contribute the invariant R_y(180):
+        // R_y(-yaw) * R_y(180) * arm == R_y(180-yaw) * arm.
+        // The generated Blockbench arm basis is reflected across X/Y relative to
+        // ModelPart's hand basis. Apply the exact Rz(180) basis conversion between
+        // the player root and arm-local rotation. This is root-local, so it remains
+        // correct for every entity yaw instead of requiring per-facing adjustments.
+        Quaternion playerRoot = new Quaternion(new Vec(0, 180, 0));
+        Quaternion armBasis = new Quaternion(new Vec(0, 0, 180));
+        return playerRoot.multiply(armBasis).multiply(local);
     }
 
     private static Point rotate(Point point, Quaternion rotation) {
@@ -179,6 +223,20 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
         q = pq.multiply(q);
 
         return q.toEuler();
+    }
+
+    /**
+     * PlayerModel rotations are expressed in Minecraft ModelPart coordinates (Y points
+     * down). The generated display cubes use the Blockbench basis (Y points up), so X/Y
+     * rotation components must be reflected for the visible cube. Held items retain the
+     * native ModelPart basis used by ItemInHandLayer.
+     */
+    private Quaternion calculateVisibleRotation() {
+        Point rotation = getPropagatedRotation();
+        Quaternion q = calculateFinalAngle(new Quaternion(new Vec(
+                -rotation.x(), -rotation.y(), rotation.z())));
+        Quaternion global = new Quaternion(new Vec(0, 180 - this.model.getGlobalRotation(), 0));
+        return global.multiply(q);
     }
 
     @Override

--- a/src/main/java/net/worldseed/gestures/ModelBoneEmote.java
+++ b/src/main/java/net/worldseed/gestures/ModelBoneEmote.java
@@ -25,12 +25,46 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
+    private static final Quaternion RIGHT_HAND_ROTATION = new Quaternion(new Vec(-90, 0, 0));
+    private static final Quaternion LEFT_HAND_ROTATION = RIGHT_HAND_ROTATION;
+    private static final double PLAYER_RENDER_SCALE = 15.0 / 16.0;
+    private static final Point RIGHT_HAND_GRIP = new Vec(
+            PLAYER_RENDER_SCALE / 16.0, -PLAYER_RENDER_SCALE * 10.0 / 16.0, -PLAYER_RENDER_SCALE * 2.0 / 16.0);
+    private static final Point LEFT_HAND_GRIP = new Vec(
+            -PLAYER_RENDER_SCALE / 16.0, -PLAYER_RENDER_SCALE * 10.0 / 16.0, -PLAYER_RENDER_SCALE * 2.0 / 16.0);
     private final Double verticalOffset;
+    private final BoneEntity heldItemStand;
+    private final Point heldItemGrip;
+    private final Quaternion heldItemRotation;
 
     public ModelBoneEmote(Point pivot, String name, Point rotation, GenericModel model, int translation, Double verticalOffset, PlayerSkin skin) {
         super(pivot, name, rotation, model, 1);
 
         this.verticalOffset = verticalOffset;
+
+        boolean rightArm = name.equals("RightArm");
+        boolean leftArm = name.equals("LeftArm");
+        this.heldItemGrip = rightArm ? RIGHT_HAND_GRIP : leftArm ? LEFT_HAND_GRIP : null;
+        this.heldItemRotation = rightArm ? RIGHT_HAND_ROTATION : leftArm ? LEFT_HAND_ROTATION : null;
+        if (rightArm || leftArm) {
+            this.heldItemStand = new BoneEntity(EntityType.ITEM_DISPLAY, model, name + "HeldItem");
+            this.heldItemStand.editEntityMeta(ItemDisplayMeta.class, meta -> {
+                meta.setViewRange(10000);
+                meta.setTransformationInterpolationDuration(2);
+                meta.setPosRotInterpolationDuration(2);
+                meta.setScale(new Vec(PLAYER_RENDER_SCALE));
+                meta.setDisplayContext(rightArm
+                        ? ItemDisplayMeta.DisplayContext.THIRDPERSON_RIGHT_HAND
+                        : ItemDisplayMeta.DisplayContext.THIRDPERSON_LEFT_HAND);
+                meta.setRightRotation(new float[]{
+                        (float) heldItemRotation.x(), (float) heldItemRotation.y(),
+                        (float) heldItemRotation.z(), (float) heldItemRotation.w()
+                });
+                meta.setItemStack(ItemStack.AIR);
+            });
+        } else {
+            this.heldItemStand = null;
+        }
 
         if (this.offset != null) {
             this.stand = new BoneEntity(EntityType.ITEM_DISPLAY, model, name);
@@ -61,7 +95,11 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
     @Override
     public CompletableFuture<Void> spawn(Instance instance, Pos position) {
         var correctLocation = (180 + this.model.getGlobalRotation() + 360) % 360;
-        return super.spawn(instance, new Pos(position).withYaw((float) correctLocation)).whenCompleteAsync((_, e) -> {
+        CompletableFuture<Void> bodySpawn = super.spawn(instance, new Pos(position).withYaw((float) correctLocation));
+        CompletableFuture<Void> itemSpawn = heldItemStand == null
+                ? CompletableFuture.completedFuture(null)
+                : heldItemStand.setInstance(instance, calculateHeldItemPosition().withYaw((float) correctLocation));
+        return CompletableFuture.allOf(bodySpawn, itemSpawn).whenCompleteAsync((_, e) -> {
             if (e != null) {
                 e.printStackTrace();
             }
@@ -89,11 +127,41 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
                 this.stand.teleport(position.withView((float) 0, 0));
             }
         }
+
+        if (this.heldItemStand != null && this.heldItemStand.getEntityMeta() instanceof ItemDisplayMeta meta) {
+            Quaternion q = new Quaternion(calculateRotation());
+            meta.setNotifyAboutChanges(false);
+            meta.setTransformationInterpolationStartDelta(0);
+            meta.setTranslation(calculateHeldItemTranslation());
+            meta.setLeftRotation(new float[]{(float) q.x(), (float) q.y(), (float) q.z(), (float) q.w()});
+            meta.setNotifyAboutChanges(true);
+            this.heldItemStand.teleport(calculateHeldItemPosition().withView(0, 0));
+        }
     }
 
     @Override
     public Pos calculatePosition() {
-        Point p = this.offset == null ? Pos.ZERO : this.offset;
+        return calculatePosition(this.offset == null ? Pos.ZERO : this.offset);
+    }
+
+    private Pos calculateHeldItemPosition() {
+        return calculatePosition();
+    }
+
+    private Point calculateHeldItemTranslation() {
+        Quaternion rotation = new Quaternion(calculateRotation());
+        return rotate(heldItemGrip.mul(scale), rotation);
+    }
+
+    private static Point rotate(Point point, Quaternion rotation) {
+        Quaternion vector = new Quaternion(point.x(), point.y(), point.z(), 0);
+        Quaternion inverse = new Quaternion(-rotation.x(), -rotation.y(), -rotation.z(), rotation.w());
+        Quaternion result = rotation.multiply(vector).multiply(inverse);
+        return new Vec(result.x(), result.y(), result.z());
+    }
+
+    private Pos calculatePosition(Point point) {
+        Point p = point;
         p = applyTransform(p);
         p = calculateGlobalRotation(p);
 
@@ -145,11 +213,33 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
     @Override
     public void addViewer(Player player) {
         if (this.stand != null) this.stand.addViewer(player);
+        if (this.heldItemStand != null) this.heldItemStand.addViewer(player);
     }
 
     @Override
     public void removeViewer(Player player) {
         if (this.stand != null) this.stand.removeViewer(player);
+        if (this.heldItemStand != null) this.heldItemStand.removeViewer(player);
+    }
+
+    public void setHeldItem(ItemStack item) {
+        if (this.heldItemStand == null) throw new IllegalStateException(name + " is not an arm bone");
+        this.heldItemStand.editEntityMeta(ItemDisplayMeta.class, meta -> meta.setItemStack(item));
+    }
+
+    public ItemStack getHeldItem() {
+        if (this.heldItemStand == null) return ItemStack.AIR;
+        return ((ItemDisplayMeta) this.heldItemStand.getEntityMeta()).getItemStack();
+    }
+
+    BoneEntity getHeldItemEntity() {
+        return this.heldItemStand;
+    }
+
+    @Override
+    public void destroy() {
+        if (this.heldItemStand != null) this.heldItemStand.remove();
+        super.destroy();
     }
 
     @Override

--- a/src/main/java/net/worldseed/gestures/ProceduralBoneAnimation.java
+++ b/src/main/java/net/worldseed/gestures/ProceduralBoneAnimation.java
@@ -1,0 +1,36 @@
+package net.worldseed.gestures;
+
+import net.minestom.server.coordinate.Point;
+import net.minestom.server.coordinate.Vec;
+import net.worldseed.multipart.ModelLoader;
+import net.worldseed.multipart.animations.AnimationHandler;
+import net.worldseed.multipart.animations.BoneAnimation;
+
+final class ProceduralBoneAnimation implements BoneAnimation {
+    private final String boneName;
+    private final ModelLoader.AnimationType type;
+    private volatile Point transform;
+
+    ProceduralBoneAnimation(String boneName, ModelLoader.AnimationType type) {
+        this.boneName = boneName;
+        this.type = type;
+        this.transform = type == ModelLoader.AnimationType.SCALE ? Vec.ONE : Vec.ZERO;
+    }
+
+    void setTransform(Point transform) {
+        this.transform = transform;
+    }
+
+    @Override public String name() { return "minecraft:player"; }
+    @Override public String boneName() { return boneName; }
+    @Override public ModelLoader.AnimationType getType() { return type; }
+    @Override public Point getTransformAtTime(int time) { return transform; }
+    @Override public boolean isPlaying() { return true; }
+    @Override public Point getTransform() { return transform; }
+    @Override public void setDirection(AnimationHandler.AnimationDirection direction) {}
+    @Override public void stop() {}
+    @Override public void play() {}
+    @Override public void tick() {}
+    @Override public void resume(short tick) {}
+    @Override public short getTick() { return 0; }
+}

--- a/src/main/java/net/worldseed/gestures/VanillaPlayerAnimationState.java
+++ b/src/main/java/net/worldseed/gestures/VanillaPlayerAnimationState.java
@@ -1,0 +1,45 @@
+package net.worldseed.gestures;
+
+/** Mutable inputs for Minecraft 26.2's third-person humanoid pose equations. */
+public final class VanillaPlayerAnimationState {
+    public enum AttackArm { RIGHT, LEFT }
+    public enum ArmPose {
+        EMPTY, ITEM, BLOCK, BOW_AND_ARROW, THROW_TRIDENT, CROSSBOW_CHARGE,
+        CROSSBOW_HOLD, SPYGLASS, TOOT_HORN, BRUSH, SPEAR
+    }
+
+    private float ageInTicks;
+    private float walkAnimationPos;
+    private float walkAnimationSpeed;
+    private float attackTime;
+    private AttackArm attackArm = AttackArm.RIGHT;
+    private float headYaw;
+    private float headPitch;
+    private boolean crouching;
+    private boolean passenger;
+    private ArmPose rightArmPose = ArmPose.EMPTY;
+    private ArmPose leftArmPose = ArmPose.EMPTY;
+
+    public float ageInTicks() { return ageInTicks; }
+    public void setAgeInTicks(float value) { ageInTicks = value; }
+    public float walkAnimationPos() { return walkAnimationPos; }
+    public void setWalkAnimationPos(float value) { walkAnimationPos = value; }
+    public float walkAnimationSpeed() { return walkAnimationSpeed; }
+    public void setWalkAnimationSpeed(float value) { walkAnimationSpeed = value; }
+    public float attackTime() { return attackTime; }
+    public void setAttackTime(float value) { attackTime = value; }
+    public AttackArm attackArm() { return attackArm; }
+    public void setAttackArm(AttackArm value) { attackArm = value; }
+    public float headYaw() { return headYaw; }
+    public void setHeadYaw(float value) { headYaw = value; }
+    public float headPitch() { return headPitch; }
+    public void setHeadPitch(float value) { headPitch = value; }
+    public boolean crouching() { return crouching; }
+    public void setCrouching(boolean value) { crouching = value; }
+    public boolean passenger() { return passenger; }
+    public void setPassenger(boolean value) { passenger = value; }
+    public ArmPose rightArmPose() { return rightArmPose; }
+    public void setRightArmPose(ArmPose value) { rightArmPose = value; }
+    public ArmPose leftArmPose() { return leftArmPose; }
+    public void setLeftArmPose(ArmPose value) { leftArmPose = value; }
+}

--- a/src/main/java/net/worldseed/gestures/VanillaPlayerPose.java
+++ b/src/main/java/net/worldseed/gestures/VanillaPlayerPose.java
@@ -1,0 +1,175 @@
+package net.worldseed.gestures;
+
+import net.minestom.server.coordinate.Point;
+import net.minestom.server.coordinate.Vec;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Direct port of the Minecraft 26.2 HumanoidModel pose equations. */
+final class VanillaPlayerPose {
+    private static final float PI = (float) Math.PI;
+
+    private VanillaPlayerPose() {}
+
+    record Pose(Map<String, Point> rotations, Map<String, Point> translations) {}
+
+    static Map<String, Point> rotations(VanillaPlayerAnimationState state) {
+        return pose(state).rotations();
+    }
+
+    static Pose pose(VanillaPlayerAnimationState state) {
+        Part head = new Part(rad(state.headPitch()), rad(state.headYaw()), 0);
+        Part body = new Part();
+        float pos = state.walkAnimationPos();
+        float speed = state.walkAnimationSpeed();
+        Part rightArm = new Part(cos(pos * 0.6662F + PI) * speed, 0, 0);
+        Part leftArm = new Part(cos(pos * 0.6662F) * speed, 0, 0);
+        Part rightLeg = new Part(cos(pos * 0.6662F) * 1.4F * speed, 0.005F, 0.005F);
+        Part leftLeg = new Part(cos(pos * 0.6662F + PI) * 1.4F * speed, -0.005F, -0.005F);
+
+        if (state.passenger()) {
+            rightArm.x += -PI / 5;
+            leftArm.x += -PI / 5;
+            rightLeg.set(-1.4137167F, PI / 10, 0.07853982F);
+            leftLeg.set(-1.4137167F, -PI / 10, -0.07853982F);
+        }
+
+        if (isTwoHanded(state.rightArmPose())) {
+            poseArm(state.rightArmPose(), rightArm, leftArm, head, true);
+        } else if (isTwoHanded(state.leftArmPose())) {
+            poseArm(state.leftArmPose(), leftArm, rightArm, head, false);
+        } else {
+            poseArm(state.rightArmPose(), rightArm, leftArm, head, true);
+            poseArm(state.leftArmPose(), leftArm, rightArm, head, false);
+        }
+        Map<String, Point> positions = basePositions();
+        attack(state.attackTime(), state.attackArm(), rightArm, leftArm, body, head, positions);
+
+        if (state.crouching()) {
+            body.x = 0.5F;
+            rightArm.x += 0.4F;
+            leftArm.x += 0.4F;
+            positions.put("Head", new Vec(0, 4.2F, 0));
+            positions.put("Body", new Vec(0, 3.2F, 0));
+            positions.put("RightArm", positions.get("RightArm").add(0, 3.2F, 0));
+            positions.put("LeftArm", positions.get("LeftArm").add(0, 3.2F, 0));
+            positions.put("RightLeg", new Vec(0, 0, 4));
+            positions.put("LeftLeg", new Vec(0, 0, 4));
+        }
+
+        if (state.rightArmPose() != VanillaPlayerAnimationState.ArmPose.SPYGLASS) bob(rightArm, state.ageInTicks(), 1);
+        if (state.leftArmPose() != VanillaPlayerAnimationState.ArmPose.SPYGLASS) bob(leftArm, state.ageInTicks(), -1);
+
+        Map<String, Point> result = new HashMap<>();
+        result.put("Head", head.degrees());
+        result.put("Body", body.degrees());
+        result.put("RightArm", rightArm.degrees());
+        result.put("LeftArm", leftArm.degrees());
+        result.put("RightLeg", rightLeg.degrees());
+        result.put("LeftLeg", leftLeg.degrees());
+        Map<String, Point> translations = new HashMap<>();
+        // ModelPart pivot offsets are pixels in vanilla's render space. Convert them to
+        // the emote bone's pre-display coordinate system and include the player's 15/16
+        // render scale.
+        positions.forEach((bone, value) -> translations.put(bone,
+                new Vec(-value.x(), -value.y(), value.z()).mul(15.0 / 64.0)));
+        if (state.crouching()) {
+            // AvatarRenderer#getRenderOffset lowers the entire crouching player by
+            // 2/16 block outside the scaled PlayerModel pose stack. In emote model
+            // coordinates (divided by four when positioned), that is -0.5 on Y.
+            translations.replaceAll((bone, value) -> value.add(0, -0.5, 0));
+        }
+        return new Pose(result, translations);
+    }
+
+    private static void poseArm(VanillaPlayerAnimationState.ArmPose pose, Part arm, Part other, Part head, boolean right) {
+        switch (pose) {
+            case EMPTY -> arm.y = 0;
+            case ITEM -> { arm.x = arm.x * 0.5F - PI / 10; arm.y = 0; }
+            case BLOCK -> {
+                arm.x = arm.x * 0.5F - 0.9424779F + clamp(head.x, -PI * 4 / 9, 0.43633232F);
+                arm.y = (right ? -PI / 6 : PI / 6) + clamp(head.y, -PI / 6, PI / 6);
+            }
+            case BOW_AND_ARROW -> {
+                arm.y = (right ? -0.1F : 0.1F) + head.y;
+                other.y = (right ? 0.5F : -0.5F) + head.y;
+                arm.x = other.x = -PI / 2 + head.x;
+            }
+            case THROW_TRIDENT -> { arm.x = arm.x * 0.5F - PI; arm.y = 0; }
+            case CROSSBOW_HOLD -> {
+                arm.y = (right ? -0.3F : 0.6F) + head.y;
+                other.y = (right ? 0.6F : -0.3F) + head.y;
+                arm.x = -PI / 2 + head.x + 0.1F;
+                other.x = -1.5F + head.x;
+            }
+            case SPYGLASS -> {
+                arm.x = clamp(head.x - 1.9198622F, -2.4F, 3.3F);
+                arm.y = head.y + (right ? -PI / 12 : PI / 12);
+            }
+            case TOOT_HORN -> {
+                arm.x = clamp(head.x, -1.2F, 1.2F) - 1.4835298F;
+                arm.y = head.y + (right ? -PI / 6 : PI / 6);
+            }
+            case BRUSH -> { arm.x = arm.x * 0.5F - PI / 5; arm.y = 0; }
+            case CROSSBOW_CHARGE, SPEAR -> { /* duration-dependent inputs are applied by the controller */ }
+        }
+    }
+
+    private static boolean isTwoHanded(VanillaPlayerAnimationState.ArmPose pose) {
+        return pose == VanillaPlayerAnimationState.ArmPose.BOW_AND_ARROW
+                || pose == VanillaPlayerAnimationState.ArmPose.CROSSBOW_CHARGE
+                || pose == VanillaPlayerAnimationState.ArmPose.CROSSBOW_HOLD;
+    }
+
+    private static void attack(float attackTime, VanillaPlayerAnimationState.AttackArm attackArm,
+                               Part rightArm, Part leftArm, Part body, Part head,
+                               Map<String, Point> positions) {
+        if (attackTime <= 0) return;
+        body.y = sin((float) Math.sqrt(attackTime) * PI * 2) * 0.2F;
+        if (attackArm == VanillaPlayerAnimationState.AttackArm.LEFT) body.y *= -1;
+        float armX = cos(body.y) * 5.0F;
+        float armZ = sin(body.y) * 5.0F;
+        positions.put("RightArm", new Vec(5.0F - armX, 0, armZ));
+        positions.put("LeftArm", new Vec(armX - 5.0F, 0, -armZ));
+        rightArm.y += body.y;
+        leftArm.y += body.y;
+        leftArm.x += body.y;
+        float swing = 1 - (float) Math.pow(1 - attackTime, 4);
+        float aa = sin(swing * PI);
+        float bb = sin(attackTime * PI) * -(head.x - 0.7F) * 0.75F;
+        Part activeArm = attackArm == VanillaPlayerAnimationState.AttackArm.RIGHT ? rightArm : leftArm;
+        activeArm.x -= aa * 1.2F + bb;
+        activeArm.y += body.y * 2;
+        activeArm.z += sin(attackTime * PI) * -0.4F;
+    }
+
+    private static Map<String, Point> basePositions() {
+        Map<String, Point> result = new HashMap<>();
+        result.put("Head", Vec.ZERO);
+        result.put("Body", Vec.ZERO);
+        result.put("RightArm", Vec.ZERO);
+        result.put("LeftArm", Vec.ZERO);
+        result.put("RightLeg", Vec.ZERO);
+        result.put("LeftLeg", Vec.ZERO);
+        return result;
+    }
+
+    private static void bob(Part arm, float age, float direction) {
+        arm.z += direction * (cos(age * 0.09F) * 0.05F + 0.05F);
+        arm.x += direction * sin(age * 0.067F) * 0.05F;
+    }
+
+    private static float rad(float degrees) { return degrees * PI / 180; }
+    private static float sin(float value) { return (float) Math.sin(value); }
+    private static float cos(float value) { return (float) Math.cos(value); }
+    private static float clamp(float value, float min, float max) { return Math.max(min, Math.min(max, value)); }
+
+    private static final class Part {
+        float x, y, z;
+        Part() {}
+        Part(float x, float y, float z) { set(x, y, z); }
+        void set(float x, float y, float z) { this.x = x; this.y = y; this.z = z; }
+        Point degrees() { return new Vec(Math.toDegrees(x), Math.toDegrees(y), Math.toDegrees(z)); }
+    }
+}

--- a/src/test/java/net/worldseed/gestures/EmoteHeldItemTest.java
+++ b/src/test/java/net/worldseed/gestures/EmoteHeldItemTest.java
@@ -1,0 +1,112 @@
+package net.worldseed.gestures;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.coordinate.Point;
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.entity.PlayerSkin;
+import net.minestom.server.entity.metadata.display.ItemDisplayMeta;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+import net.worldseed.multipart.ModelLoader;
+import net.worldseed.multipart.animations.AnimationHandler;
+import net.worldseed.multipart.animations.BoneAnimation;
+import net.worldseed.multipart.model_bones.ModelBoneImpl;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class EmoteHeldItemTest {
+    private static Instance instance;
+
+    @BeforeAll
+    static void startServer() {
+        MinecraftServer.init();
+        instance = MinecraftServer.getInstanceManager().createInstanceContainer();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        MinecraftServer.stopCleanly();
+    }
+
+    @Test
+    void itemsUseTheCorrectHandContextAndCanBeCleared() {
+        EmoteModel model = model();
+        ItemStack sword = ItemStack.of(Material.DIAMOND_SWORD);
+        ItemStack shield = ItemStack.of(Material.SHIELD);
+
+        model.setMainHandItem(sword);
+        model.setOffHandItem(shield);
+
+        assertEquals(sword, model.getMainHandItem());
+        assertEquals(shield, model.getOffHandItem());
+        assertEquals(ItemDisplayMeta.DisplayContext.THIRDPERSON_RIGHT_HAND, heldMeta(model, "RightArm").getDisplayContext());
+        assertEquals(ItemDisplayMeta.DisplayContext.THIRDPERSON_LEFT_HAND, heldMeta(model, "LeftArm").getDisplayContext());
+        assertEquals(15.0 / 256.0, Math.abs(heldMeta(model, "RightArm").getTranslation().x()), 1.0e-6);
+        assertEquals(15.0 / 256.0, Math.abs(heldMeta(model, "LeftArm").getTranslation().x()), 1.0e-6);
+        assertEquals(-15.0 * 10.0 / 256.0, heldMeta(model, "RightArm").getTranslation().y(), 1.0e-6);
+        assertEquals(-15.0 * 10.0 / 256.0, heldMeta(model, "LeftArm").getTranslation().y(), 1.0e-6);
+        assertEquals(15.0 / 16.0, heldMeta(model, "RightArm").getScale().x(), 1.0e-6);
+        assertArrayEquals(
+                heldMeta(model, "RightArm").getRightRotation(),
+                heldMeta(model, "LeftArm").getRightRotation());
+
+        model.setMainHandItem(ItemStack.AIR);
+        model.setOffHandItem(ItemStack.AIR);
+        assertEquals(ItemStack.AIR, model.getMainHandItem());
+        assertEquals(ItemStack.AIR, model.getOffHandItem());
+        model.destroy();
+    }
+
+    @Test
+    void heldItemMovesWithItsAnimatedArm() {
+        EmoteModel model = model();
+        ModelBoneEmote arm = (ModelBoneEmote) model.getPart("RightArm");
+        float[] resting = heldMeta(model, "RightArm").getLeftRotation();
+        Point restingGrip = heldMeta(model, "RightArm").getTranslation();
+
+        arm.addAnimation(rotation(new Vec(0, 0, 90)));
+        ModelBoneImpl.beginDrawFrame();
+        model.draw();
+
+        assertFalse(java.util.Arrays.equals(resting, heldMeta(model, "RightArm").getLeftRotation()));
+        assertNotEquals(restingGrip, heldMeta(model, "RightArm").getTranslation());
+        assertEquals(arm.getEntity().getPosition(), arm.getHeldItemEntity().getPosition());
+        model.destroy();
+    }
+
+    private static EmoteModel model() {
+        EmoteModel model = new EmoteModel(new PlayerSkin("", ""));
+        model.init(instance, Pos.ZERO);
+        return model;
+    }
+
+    private static ItemDisplayMeta heldMeta(EmoteModel model, String armName) {
+        ModelBoneEmote arm = (ModelBoneEmote) model.getPart(armName);
+        return (ItemDisplayMeta) arm.getHeldItemEntity().getEntityMeta();
+    }
+
+    private static BoneAnimation rotation(Point value) {
+        return new BoneAnimation() {
+            @Override public String name() { return "test"; }
+            @Override public String boneName() { return "RightArm"; }
+            @Override public ModelLoader.AnimationType getType() { return ModelLoader.AnimationType.ROTATION; }
+            @Override public Point getTransformAtTime(int time) { return value; }
+            @Override public boolean isPlaying() { return true; }
+            @Override public Point getTransform() { return value; }
+            @Override public void setDirection(AnimationHandler.AnimationDirection direction) { }
+            @Override public void stop() { }
+            @Override public void play() { }
+            @Override public void tick() { }
+            @Override public void resume(short tick) { }
+            @Override public short getTick() { return 0; }
+        };
+    }
+}

--- a/src/test/java/net/worldseed/gestures/EmoteHeldItemTest.java
+++ b/src/test/java/net/worldseed/gestures/EmoteHeldItemTest.java
@@ -1,10 +1,14 @@
 package net.worldseed.gestures;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.PlayerSkin;
+import net.minestom.server.entity.EquipmentSlot;
 import net.minestom.server.entity.metadata.display.ItemDisplayMeta;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.item.ItemStack;
@@ -17,10 +21,16 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EmoteHeldItemTest {
     private static Instance instance;
@@ -37,6 +47,48 @@ class EmoteHeldItemTest {
     }
 
     @Test
+    void emotePlayerUsesMinestomEquipmentAndWseeEntityApis() {
+        EmotePlayer player = new EmotePlayer(instance, Pos.ZERO, new PlayerSkin("", ""));
+        ItemStack sword = ItemStack.of(Material.DIAMOND_SWORD);
+        ItemStack shield = ItemStack.of(Material.SHIELD);
+
+        player.setItemInMainHand(sword);
+        player.setItemInOffHand(shield);
+
+        assertTrue(player.isInvisible());
+        assertSame(player, player.getModel().getOwner());
+        assertNotNull(player.getAnimationHandler());
+        assertEquals(sword, player.getItemInMainHand());
+        assertEquals(shield, player.getItemInOffHand());
+        assertEquals(sword, player.getEquipment(EquipmentSlot.MAIN_HAND));
+        assertEquals(shield, player.getEquipment(EquipmentSlot.OFF_HAND));
+        assertEquals(sword, player.getModel().getMainHandItem());
+        assertEquals(shield, player.getModel().getOffHandItem());
+        assertEquals(0.1, player.getAttributeValue(net.minestom.server.entity.attribute.Attribute.MOVEMENT_SPEED), 1.0e-6);
+        player.swingOffHand();
+        assertEquals(VanillaPlayerAnimationState.AttackArm.LEFT, player.vanillaAnimationState().attackArm());
+        assertEquals(1.0, player.vanillaAnimationState().attackTime(), 1.0e-6);
+
+        player.clearHandItems();
+        assertEquals(ItemStack.AIR, player.getItemInMainHand());
+        assertEquals(ItemStack.AIR, player.getItemInOffHand());
+        player.remove();
+    }
+
+    @Test
+    void ordinaryMinestomVelocityDrivesWalkingAndTheWseeModel() {
+        EmotePlayer player = new EmotePlayer(instance, new Pos(0, 10, 0), new PlayerSkin("", ""));
+        Pos before = player.getPosition();
+        player.setVelocity(new Vec(1, 0, 0));
+        player.tick(0);
+
+        assertNotEquals(before, player.getPosition());
+        assertTrue(player.vanillaAnimationState().walkAnimationSpeed() > 0);
+        assertEquals(player.getPosition(), player.getModel().getPosition());
+        player.remove();
+    }
+
+    @Test
     void itemsUseTheCorrectHandContextAndCanBeCleared() {
         EmoteModel model = model();
         ItemStack sword = ItemStack.of(Material.DIAMOND_SWORD);
@@ -49,11 +101,18 @@ class EmoteHeldItemTest {
         assertEquals(shield, model.getOffHandItem());
         assertEquals(ItemDisplayMeta.DisplayContext.THIRDPERSON_RIGHT_HAND, heldMeta(model, "RightArm").getDisplayContext());
         assertEquals(ItemDisplayMeta.DisplayContext.THIRDPERSON_LEFT_HAND, heldMeta(model, "LeftArm").getDisplayContext());
-        assertEquals(15.0 / 256.0, Math.abs(heldMeta(model, "RightArm").getTranslation().x()), 1.0e-6);
-        assertEquals(15.0 / 256.0, Math.abs(heldMeta(model, "LeftArm").getTranslation().x()), 1.0e-6);
+        assertEquals(-15.0 / 256.0, heldMeta(model, "RightArm").getTranslation().x(), 1.0e-6);
+        assertEquals(15.0 / 256.0, heldMeta(model, "LeftArm").getTranslation().x(), 1.0e-6);
         assertEquals(-15.0 * 10.0 / 256.0, heldMeta(model, "RightArm").getTranslation().y(), 1.0e-6);
         assertEquals(-15.0 * 10.0 / 256.0, heldMeta(model, "LeftArm").getTranslation().y(), 1.0e-6);
         assertEquals(15.0 / 16.0, heldMeta(model, "RightArm").getScale().x(), 1.0e-6);
+        // The resource-pack model already contains vanilla's 15/16 render scale.
+        // Metadata must remain identity or each independently-centred bone develops gaps.
+        assertEquals(1.0, visibleMeta(model, "RightArm").getScale().x(), 1.0e-6);
+        assertEquals(1, heldMeta(model, "RightArm").getTransformationInterpolationDuration());
+        assertEquals(1, heldMeta(model, "RightArm").getPosRotInterpolationDuration());
+        assertEquals(1, visibleMeta(model, "RightArm").getTransformationInterpolationDuration());
+        assertEquals(1, visibleMeta(model, "RightArm").getPosRotInterpolationDuration());
         assertArrayEquals(
                 heldMeta(model, "RightArm").getRightRotation(),
                 heldMeta(model, "LeftArm").getRightRotation());
@@ -78,8 +137,84 @@ class EmoteHeldItemTest {
 
         assertFalse(java.util.Arrays.equals(resting, heldMeta(model, "RightArm").getLeftRotation()));
         assertNotEquals(restingGrip, heldMeta(model, "RightArm").getTranslation());
-        assertEquals(arm.getEntity().getPosition(), arm.getHeldItemEntity().getPosition());
+        assertEquals(arm.getEntity().getPosition().x(),
+                arm.getHeldItemEntity().getPosition().x(), 1.0e-6);
+        assertEquals(arm.getEntity().getPosition().y() - 0.11, arm.getHeldItemEntity().getPosition().y(), 1.0e-6);
+        double expectedDepth = 0.585033 - 1.0546875 * Math.sin(Math.toRadians(18.0));
+        assertEquals(arm.getEntity().getPosition().z() + expectedDepth,
+                arm.getHeldItemEntity().getPosition().z(), 1.0e-6);
         model.destroy();
+    }
+
+    @Test
+    void idleBobKeepsBothItemsOnTheVanillaHandPivot() {
+        EmoteModel model = model();
+        VanillaPlayerAnimationState state = new VanillaPlayerAnimationState();
+        state.setRightArmPose(VanillaPlayerAnimationState.ArmPose.ITEM);
+        state.setLeftArmPose(VanillaPlayerAnimationState.ArmPose.ITEM);
+        state.setAgeInTicks(20.0f);
+        model.applyVanillaPose(state);
+
+        double bobX = Math.sin(20.0 * 0.067) * 0.05;
+        double rightDepth = 0.585033 - 1.0546875 * Math.sin(bobX);
+        double leftDepth = 0.585033 + 1.0546875 * Math.sin(bobX);
+        ModelBoneEmote right = (ModelBoneEmote) model.getPart("RightArm");
+        ModelBoneEmote left = (ModelBoneEmote) model.getPart("LeftArm");
+
+        assertEquals(right.getEntity().getPosition().z() + rightDepth,
+                right.getHeldItemEntity().getPosition().z(), 1.0e-6);
+        assertEquals(left.getEntity().getPosition().z() + leftDepth,
+                left.getHeldItemEntity().getPosition().z(), 1.0e-6);
+        model.destroy();
+    }
+
+    @Test
+    void wholeModelRotationStaysOutsideTheLocalHandTransform() {
+        EmoteModel model = model();
+        VanillaPlayerAnimationState state = new VanillaPlayerAnimationState();
+        state.setAgeInTicks(0);
+        state.setRightArmPose(VanillaPlayerAnimationState.ArmPose.ITEM);
+        model.applyVanillaPose(state);
+
+        ItemDisplayMeta meta = heldMeta(model, "RightArm");
+        Point localGrip = meta.getTranslation();
+        float[] localRotation = meta.getLeftRotation();
+
+        model.setGlobalRotation(90);
+        model.applyVanillaPose(state);
+
+        assertEquals(localGrip, meta.getTranslation());
+        assertArrayEquals(localRotation, meta.getLeftRotation());
+        assertEquals(90, ((ModelBoneEmote) model.getPart("RightArm")).getHeldItemEntity().getPosition().yaw(), 1.0e-6);
+        model.destroy();
+    }
+
+    @Test
+    void blockbenchCubesMatchVanillaPlayerModelAroundTheirPivots() throws Exception {
+        try (var stream = getClass().getResourceAsStream("/bbmodel/steve.bbmodel")) {
+            assertNotNull(stream);
+            JsonObject model = JsonParser.parseReader(new InputStreamReader(stream, StandardCharsets.UTF_8)).getAsJsonObject();
+            JsonArray elements = model.getAsJsonArray("elements");
+            var expected = java.util.Map.of(
+                    "Head", new double[]{-4, 24, -4, 4, 32, 4},
+                    "Body", new double[]{-4, 12, -2, 4, 24, 2},
+                    "Right Arm", new double[]{4, 12, -2, 8, 24, 2},
+                    "Left Arm", new double[]{-8, 12, -2, -4, 24, 2},
+                    "Right Leg", new double[]{-3.9, 0, -2, 0.1, 12, 2},
+                    "Left Leg", new double[]{-0.1, 0, -2, 3.9, 12, 2});
+            var counts = new java.util.HashMap<String, Integer>();
+            for (var value : elements) {
+                JsonObject cube = value.getAsJsonObject();
+                String name = cube.get("name").getAsString();
+                double[] bounds = expected.get(name);
+                assertNotNull(bounds, "unexpected player cube " + name);
+                assertVec(cube.getAsJsonArray("from"), bounds[0], bounds[1], bounds[2]);
+                assertVec(cube.getAsJsonArray("to"), bounds[3], bounds[4], bounds[5]);
+                counts.merge(name, 1, Integer::sum);
+            }
+            // Base skin plus outer skin layer for every vanilla part.
+            expected.keySet().forEach(name -> assertEquals(2, counts.get(name), name));
+        }
     }
 
     private static EmoteModel model() {
@@ -91,6 +226,11 @@ class EmoteHeldItemTest {
     private static ItemDisplayMeta heldMeta(EmoteModel model, String armName) {
         ModelBoneEmote arm = (ModelBoneEmote) model.getPart(armName);
         return (ItemDisplayMeta) arm.getHeldItemEntity().getEntityMeta();
+    }
+
+    private static ItemDisplayMeta visibleMeta(EmoteModel model, String boneName) {
+        ModelBoneEmote bone = (ModelBoneEmote) model.getPart(boneName);
+        return (ItemDisplayMeta) bone.getEntity().getEntityMeta();
     }
 
     private static BoneAnimation rotation(Point value) {
@@ -108,5 +248,11 @@ class EmoteHeldItemTest {
             @Override public void resume(short tick) { }
             @Override public short getTick() { return 0; }
         };
+    }
+
+    private static void assertVec(JsonArray actual, double x, double y, double z) {
+        assertEquals(x, actual.get(0).getAsDouble(), 1.0e-9);
+        assertEquals(y, actual.get(1).getAsDouble(), 1.0e-9);
+        assertEquals(z, actual.get(2).getAsDouble(), 1.0e-9);
     }
 }

--- a/src/test/resources/bbmodel/steve.bbmodel
+++ b/src/test/resources/bbmodel/steve.bbmodel
@@ -1,1 +1,1482 @@
-{"meta":{"format_version":"4.0","creation_time":1670974902,"model_format":"free","box_uv":false},"name":"steve","geometry_name":"steve","visible_box":[1,1,0],"variable_placeholders":"","resolution":{"width":64,"height":64},"elements":[{"name":"Head","rescale":false,"locked":false,"from":[-1.4976000000000003,8.985600000000002,-1.4976000000000003],"to":[1.4976000000000003,11.980800000000002,1.4976000000000003],"autouv":0,"color":0,"origin":[0,0,0],"faces":{"north":{"uv":[8,8,16,16],"texture":0},"east":{"uv":[0,8,8,16],"texture":0},"south":{"uv":[24,8,32,16],"texture":0},"west":{"uv":[16,8,24,16],"texture":0},"up":{"uv":[16,8,8,0],"texture":0},"down":{"uv":[24,0,16,8],"texture":0}},"uuid":"5104fb89-1a1a-e54e-8ea7-a3d422092d34"},{"name":"Body","rescale":false,"locked":false,"from":[-1.4976000000000003,4.492800000000001,-0.7488000000000001],"to":[1.4976000000000003,8.985600000000002,0.7488000000000001],"autouv":0,"color":0,"origin":[0,0,0],"uv_offset":[16,16],"faces":{"north":{"uv":[20,20,28,32],"texture":0},"east":{"uv":[16,20,20,32],"texture":0},"south":{"uv":[32,20,40,32],"texture":0},"west":{"uv":[28,20,32,32],"texture":0},"up":{"uv":[28,20,20,16],"texture":0},"down":{"uv":[36,16,28,20],"texture":0}},"uuid":"537a1485-6b1a-1a8b-5a45-b46940212841"},{"name":"Right Arm","rescale":false,"locked":false,"from":[1.4976000000000003,4.492800000000001,-0.7488000000000001],"to":[2.9952000000000005,8.985600000000002,0.7488000000000001],"autouv":0,"color":0,"origin":[0,0,0],"uv_offset":[40,16],"faces":{"north":{"uv":[44,20,48,32],"texture":0},"east":{"uv":[40,20,44,32],"texture":0},"south":{"uv":[52,20,56,32],"texture":0},"west":{"uv":[48,20,52,32],"texture":0},"up":{"uv":[48,20,44,16],"texture":0},"down":{"uv":[52,16,48,20],"texture":0}},"uuid":"1120b3a0-bd40-cec6-d45a-f9c09fe6bd59"},{"name":"Left Arm","rescale":false,"locked":false,"from":[-2.9952000000000005,4.492800000000001,-0.7488000000000001],"to":[-1.4976000000000003,8.985600000000002,0.7488000000000001],"autouv":0,"color":0,"origin":[0,0,0],"uv_offset":[32,48],"faces":{"north":{"uv":[36,52,40,64],"texture":0},"east":{"uv":[32,52,36,64],"texture":0},"south":{"uv":[44,52,48,64],"texture":0},"west":{"uv":[40,52,44,64],"texture":0},"up":{"uv":[40,52,36,48],"texture":0},"down":{"uv":[44,48,40,52],"texture":0}},"uuid":"38ae66fa-1d04-98fe-7c9f-80d6d927c476"},{"name":"Right Leg","rescale":false,"locked":false,"from":[1.3885498084675874e-8,0,-0.7488000000000001],"to":[1.4976000138854983,4.492800000000001,0.7488000000000001],"autouv":0,"color":0,"origin":[0.03744001388549805,0,0],"uv_offset":[0,16],"faces":{"north":{"uv":[4,20,8,32],"texture":0},"east":{"uv":[0,20,4,32],"texture":0},"south":{"uv":[12,20,16,32],"texture":0},"west":{"uv":[8,20,12,32],"texture":0},"up":{"uv":[8,20,4,16],"texture":0},"down":{"uv":[12,16,8,20],"texture":0}},"uuid":"3729df3c-fde6-8e55-83f2-45c8cf53670a"},{"name":"Left Leg","rescale":false,"locked":false,"from":[-1.4976000138854983,0,-0.7488000000000001],"to":[-1.3885498012511378e-8,4.492800000000001,0.7488000000000001],"autouv":0,"color":0,"origin":[-0.03744001388549805,0,0],"uv_offset":[16,48],"faces":{"north":{"uv":[20,52,24,64],"texture":0},"east":{"uv":[16,52,20,64],"texture":0},"south":{"uv":[28,52,32,64],"texture":0},"west":{"uv":[24,52,28,64],"texture":0},"up":{"uv":[24,52,20,48],"texture":0},"down":{"uv":[28,48,24,52],"texture":0}},"uuid":"40514c77-fe66-f7fa-2f74-ec7d4c8c20a8"},{"name":"Head","rescale":false,"locked":false,"from":[-1.4976000000000003,8.985600000000002,-1.4976000000000003],"to":[1.4976000000000003,11.980800000000002,1.4976000000000003],"autouv":0,"color":0,"origin":[0,0,0],"faces":{"north":{"uv":[8,8,16,16],"texture":0},"east":{"uv":[0,8,8,16],"texture":0},"south":{"uv":[24,8,32,16],"texture":0},"west":{"uv":[16,8,24,16],"texture":0},"up":{"uv":[16,8,8,0],"texture":0},"down":{"uv":[24,0,16,8],"texture":0}},"uuid":"fe6cb237-94c0-a777-589e-28b1348d0e1c"},{"name":"Body","rescale":false,"locked":false,"from":[-1.4976000000000003,4.492800000000001,-0.7488000000000001],"to":[1.4976000000000003,8.985600000000002,0.7488000000000001],"autouv":0,"color":0,"origin":[0,0,0],"uv_offset":[16,16],"faces":{"north":{"uv":[20,20,28,32],"texture":0},"east":{"uv":[16,20,20,32],"texture":0},"south":{"uv":[32,20,40,32],"texture":0},"west":{"uv":[28,20,32,32],"texture":0},"up":{"uv":[28,20,20,16],"texture":0},"down":{"uv":[36,16,28,20],"texture":0}},"uuid":"1992eb79-db93-7d2f-577d-e939ca7112a7"},{"name":"Right Arm","rescale":false,"locked":false,"from":[1.4976000000000003,4.492800000000001,-0.7488000000000001],"to":[2.9952000000000005,8.985600000000002,0.7488000000000001],"autouv":0,"color":0,"origin":[0,0,0],"uv_offset":[40,16],"faces":{"north":{"uv":[44,20,48,32],"texture":0},"east":{"uv":[40,20,44,32],"texture":0},"south":{"uv":[52,20,56,32],"texture":0},"west":{"uv":[48,20,52,32],"texture":0},"up":{"uv":[48,20,44,16],"texture":0},"down":{"uv":[52,16,48,20],"texture":0}},"uuid":"cd3961db-9a82-4036-48c9-6f0c0f5ff492"},{"name":"Left Arm","rescale":false,"locked":false,"from":[-2.9952000000000005,4.492800000000001,-0.7488000000000001],"to":[-1.4976000000000003,8.985600000000002,0.7488000000000001],"autouv":0,"color":0,"origin":[0,0,0],"uv_offset":[32,48],"faces":{"north":{"uv":[36,52,40,64],"texture":0},"east":{"uv":[32,52,36,64],"texture":0},"south":{"uv":[44,52,48,64],"texture":0},"west":{"uv":[40,52,44,64],"texture":0},"up":{"uv":[40,52,36,48],"texture":0},"down":{"uv":[44,48,40,52],"texture":0}},"uuid":"6ebcfd34-e49e-13cf-4fe4-5168544f581d"},{"name":"Right Leg","rescale":false,"locked":false,"from":[1.3885498084675874e-8,0,-0.7488000000000001],"to":[1.4976000138854983,4.492800000000001,0.7488000000000001],"autouv":0,"color":0,"origin":[0.03744001388549805,0,0],"uv_offset":[0,16],"faces":{"north":{"uv":[4,20,8,32],"texture":0},"east":{"uv":[0,20,4,32],"texture":0},"south":{"uv":[12,20,16,32],"texture":0},"west":{"uv":[8,20,12,32],"texture":0},"up":{"uv":[8,20,4,16],"texture":0},"down":{"uv":[12,16,8,20],"texture":0}},"uuid":"67227267-5728-6632-bfe5-b68dfca3edda"},{"name":"Left Leg","rescale":false,"locked":false,"from":[-1.4976000138854983,0,-0.7488000000000001],"to":[-1.3885498012511378e-8,4.492800000000001,0.7488000000000001],"autouv":0,"color":0,"origin":[-0.03744001388549805,0,0],"uv_offset":[16,48],"faces":{"north":{"uv":[20,52,24,64],"texture":0},"east":{"uv":[16,52,20,64],"texture":0},"south":{"uv":[28,52,32,64],"texture":0},"west":{"uv":[24,52,28,64],"texture":0},"up":{"uv":[24,52,20,48],"texture":0},"down":{"uv":[28,48,24,52],"texture":0}},"uuid":"79fd4620-0638-4b17-dde8-7912e6713b30"}],"outliner":[{"name":"model","origin":[0,0,0],"color":0,"uuid":"7faeac9f-c0d7-3388-e070-b585d13e9bc6","export":true,"isOpen":true,"locked":false,"visibility":true,"autouv":0,"children":[{"name":"right_leg","origin":[0.71136,4.492800000000001,0],"color":0,"uuid":"effb1715-03da-1e40-3f78-23b543364775","export":true,"isOpen":true,"locked":false,"visibility":true,"autouv":0,"children":["3729df3c-fde6-8e55-83f2-45c8cf53670a","67227267-5728-6632-bfe5-b68dfca3edda"]},{"name":"left_leg","origin":[-0.71136,4.492800000000001,0],"color":0,"uuid":"9d6c2fa2-e5c9-2c91-13bb-e1beee58ca0e","export":true,"isOpen":true,"locked":false,"visibility":true,"autouv":0,"children":["40514c77-fe66-f7fa-2f74-ec7d4c8c20a8","79fd4620-0638-4b17-dde8-7912e6713b30"]},{"name":"torso","origin":[0,4.4,0],"color":0,"uuid":"c6e264bb-1995-8bff-5219-133f84c0375f","export":true,"isOpen":true,"locked":false,"visibility":true,"autouv":0,"children":[{"name":"body","origin":[0,4.585600000000001,0],"color":0,"uuid":"48788d44-9245-5a93-e645-02262d97a81a","export":true,"isOpen":true,"locked":false,"visibility":true,"autouv":0,"children":["537a1485-6b1a-1a8b-5a45-b46940212841","1992eb79-db93-7d2f-577d-e939ca7112a7",{"name":"right_arm","origin":[1.8720000000000003,8.2368,0],"color":0,"uuid":"80471ca3-4418-b60a-7ddb-ea4203c4b426","export":true,"isOpen":true,"locked":false,"visibility":true,"autouv":0,"children":["1120b3a0-bd40-cec6-d45a-f9c09fe6bd59","cd3961db-9a82-4036-48c9-6f0c0f5ff492"]},{"name":"left_arm","origin":[-1.8720000000000003,8.2368,0],"color":0,"uuid":"6cf941fc-831e-8f37-ffe3-ec8a9e7da7ad","export":true,"isOpen":true,"locked":false,"visibility":true,"autouv":0,"children":["38ae66fa-1d04-98fe-7c9f-80d6d927c476","6ebcfd34-e49e-13cf-4fe4-5168544f581d"]}]},{"name":"_head","origin":[0,8.985600000000002,0],"color":0,"uuid":"36d6b66f-29a5-1c3a-a9b2-3a623d5b093a","export":true,"isOpen":true,"locked":false,"visibility":true,"autouv":0,"children":["5104fb89-1a1a-e54e-8ea7-a3d422092d34","fe6cb237-94c0-a777-589e-28b1348d0e1c"]}]}]}],"textures":[{"path":"/home/ace/Programming/Minecraft/WorldSeedEntityEngine/src/test/resources/bbmodel/steve.png","name":"steve.png","folder":"","namespace":"","id":"0","particle":false,"render_mode":"normal","visible":true,"mode":"bitmap","saved":false,"uuid":"7073fa2a-3dd2-730b-f192-db9edb75c207","source":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAACTUlEQVR4Xu1bvUoDQRDeE0ExvQlERFHwAWzSW9rZ+Aj2PodJoZVVnkArHyIIdmkEwR8MJGIbwcaVISdcxnVnz93lLnefjcXu7c5+O/PNN7ubRAl/N8NnbevS715YR7jqnyXSHEW2i8YRAJ3dDaONg4dXRQC0my1j+2gyVgAAHoAQEMMMHFAgAuLugASrngYPxl1rnm8NT6wOenl7bm1fPn63tq/u9EQvjBkhCQHQaa6b8/zkTREAW62Gsf1pPFUEQGN709g+fXxRBMBKe8/Y/jm6VwBgETzgdH/mAdej2UYetWf/e3c18YDaAwAOqDoJ2tJM5dMgXzyv/3m9L5W3sc8PfO3j6/0lQrLSl9f7LvV9bOnsax8AYAgYPSDbp/IhwGsBTnpc63Ntf9hIVVGKWl7SlGoFaXzJPklqz9UCA6b9udbn2p60PBn4U0vw73m8SePx/tL40ngutQYAyFaD8ACEwHz97xJj4ACQILIA0iB0QHqourBCKKvAaieFY565L8LYhV5KlAEgAFCGXSjSBnhAkeiXYW54QBl2IZcNa1qrjyTYxpkGovcCwSbItTiXzgAAHoAQAAcQVwQiwr9IkKYoLxG6kKVjn1os0oYFAHD0FOduvvf3vt87G5p2DO4Bvvf3vt8DgJwIRPGAkO8L8r5PyLl+/1QX+32B7/2/BIi3B8S8XXa5m5QeQAAAAYFKe8CSVvorsYe5FQCtlE4ESVzmEAAA8ACEQH05gOKfEsC/SZAIMD0UsBJlmUlQ0gBBDj0AAPvZXej3BbGl8Dck67KM7ElDfgAAAABJRU5ErkJggg==","relative_path":"../steve.png"}],"animations":[{"uuid":"19467591-ad5e-b55a-f152-f9717f26c050","name":"dab","loop":"once","override":false,"length":2,"snapping":20,"selected":false,"anim_time_update":"","blend_weight":"","start_delay":"","loop_delay":"","animators":{"36d6b66f-29a5-1c3a-a9b2-3a623d5b093a":{"name":"_head","keyframes":[{"channel":"rotation","data_points":[{"x":"0","y":"0","z":"0"}],"uuid":"a72ae329-4f0b-b08d-8f66-f85be9912698","time":0,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":32.5,"y":0,"z":0}],"uuid":"198b1592-c9e8-d161-1155-a87ee8e081a1","time":0.45,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":"0","y":"0","z":"0"}],"uuid":"bafaa86c-6877-15a0-01a2-8a4ef6788471","time":1.8,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":32.5,"y":0,"z":0}],"uuid":"13b0ac91-9b3e-b701-a239-aa9b51e18343","time":1.45,"color":-1,"interpolation":"linear"}]},"80471ca3-4418-b60a-7ddb-ea4203c4b426":{"name":"right_arm","keyframes":[{"channel":"rotation","data_points":[{"x":"0","y":"0","z":"0"}],"uuid":"07ce2e66-858b-4001-65f8-144c1152b772","time":0,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":-47.5,"y":0,"z":-100}],"uuid":"65073d92-a0da-1de1-dc8a-28be02514aca","time":0.45,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":"0","y":0,"z":"100"}],"uuid":"f14e103b-bb71-0401-e922-661b4d403cfe","time":0.85,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":-47.5,"y":0,"z":-100}],"uuid":"f09867cc-ea33-6f5c-140c-77eed2b03429","time":1.25,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":"0","y":"0","z":"0"}],"uuid":"42d8c0ba-9dd7-c8f2-43cc-adf3fd9520d0","time":1.8,"color":-1,"interpolation":"linear"}]},"6cf941fc-831e-8f37-ffe3-ec8a9e7da7ad":{"name":"left_arm","keyframes":[{"channel":"rotation","data_points":[{"x":"0","y":"0","z":"0"}],"uuid":"afe5fbf8-4f8e-957a-ca33-fbf47b6c36c5","time":0,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":0,"y":0,"z":-100}],"uuid":"eec5ffce-c00f-6b52-a294-3296f274702c","time":0.45,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":"-47.5","y":0,"z":"100"}],"uuid":"5459fe31-1c20-3e6b-1241-52f8051c5b1e","time":0.85,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":0,"y":0,"z":-100}],"uuid":"2ea11f77-f276-ffdc-bd4d-370f6bc034d5","time":1.25,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":"0","y":"0","z":"0"}],"uuid":"839a3c4d-ec9d-8054-e028-3b7493ad490e","time":1.8,"color":-1,"interpolation":"linear"}]},"9d6c2fa2-e5c9-2c91-13bb-e1beee58ca0e":{"name":"left_leg","keyframes":[{"channel":"rotation","data_points":[{"x":"0","y":"0","z":"0"}],"uuid":"a064e2eb-bdb2-ca58-fe3f-61354e79967e","time":0,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":10,"y":0,"z":0}],"uuid":"47bc767f-8cf8-13b2-87b3-e4f6b18cc04d","time":1.45,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":"0","y":"0","z":"0"}],"uuid":"342059fb-8a37-fbe0-3a2f-b050152e3c5b","time":1.8,"color":-1,"interpolation":"linear"}]},"c6e264bb-1995-8bff-5219-133f84c0375f":{"name":"torso","keyframes":[{"channel":"rotation","data_points":[{"x":"0","y":"0","z":"0"}],"uuid":"c3e8b0f2-6f67-2f5c-fcfe-456da83e51c4","time":0,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":5,"y":0,"z":0}],"uuid":"19b04d2b-4ed1-7743-bab3-98573839b4c2","time":1.45,"color":-1,"interpolation":"linear"},{"channel":"rotation","data_points":[{"x":"0","y":"0","z":"0"}],"uuid":"cc8e918e-66c5-b40c-8e7e-9061646c243c","time":1.8,"color":-1,"interpolation":"linear"}]}}}]}
+{
+  "meta": {
+    "format_version": "4.0",
+    "creation_time": 1670974902,
+    "model_format": "free",
+    "box_uv": false
+  },
+  "name": "steve",
+  "geometry_name": "steve",
+  "visible_box": [
+    1,
+    1,
+    0
+  ],
+  "variable_placeholders": "",
+  "resolution": {
+    "width": 64,
+    "height": 64
+  },
+  "elements": [
+    {
+      "name": "Head",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        -4,
+        24,
+        -4
+      ],
+      "to": [
+        4,
+        32,
+        4
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        0,
+        0,
+        0
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            8,
+            8,
+            16,
+            16
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            0,
+            8,
+            8,
+            16
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            24,
+            8,
+            32,
+            16
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            16,
+            8,
+            24,
+            16
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            16,
+            8,
+            8,
+            0
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            24,
+            0,
+            16,
+            8
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "5104fb89-1a1a-e54e-8ea7-a3d422092d34"
+    },
+    {
+      "name": "Body",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        -4,
+        12,
+        -2
+      ],
+      "to": [
+        4,
+        24,
+        2
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        0,
+        0,
+        0
+      ],
+      "uv_offset": [
+        16,
+        16
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            20,
+            20,
+            28,
+            32
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            16,
+            20,
+            20,
+            32
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            32,
+            20,
+            40,
+            32
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            28,
+            20,
+            32,
+            32
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            28,
+            20,
+            20,
+            16
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            36,
+            16,
+            28,
+            20
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "537a1485-6b1a-1a8b-5a45-b46940212841"
+    },
+    {
+      "name": "Right Arm",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        4,
+        12,
+        -2
+      ],
+      "to": [
+        8,
+        24,
+        2
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        0,
+        0,
+        0
+      ],
+      "uv_offset": [
+        40,
+        16
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            44,
+            20,
+            48,
+            32
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            40,
+            20,
+            44,
+            32
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            52,
+            20,
+            56,
+            32
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            48,
+            20,
+            52,
+            32
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            48,
+            20,
+            44,
+            16
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            52,
+            16,
+            48,
+            20
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "1120b3a0-bd40-cec6-d45a-f9c09fe6bd59"
+    },
+    {
+      "name": "Left Arm",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        -8,
+        12,
+        -2
+      ],
+      "to": [
+        -4,
+        24,
+        2
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        0,
+        0,
+        0
+      ],
+      "uv_offset": [
+        32,
+        48
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            36,
+            52,
+            40,
+            64
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            32,
+            52,
+            36,
+            64
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            44,
+            52,
+            48,
+            64
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            40,
+            52,
+            44,
+            64
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            40,
+            52,
+            36,
+            48
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            44,
+            48,
+            40,
+            52
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "38ae66fa-1d04-98fe-7c9f-80d6d927c476"
+    },
+    {
+      "name": "Right Leg",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        -3.9,
+        0,
+        -2
+      ],
+      "to": [
+        0.1,
+        12,
+        2
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        0.03744001388549805,
+        0,
+        0
+      ],
+      "uv_offset": [
+        0,
+        16
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            4,
+            20,
+            8,
+            32
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            0,
+            20,
+            4,
+            32
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            12,
+            20,
+            16,
+            32
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            8,
+            20,
+            12,
+            32
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            8,
+            20,
+            4,
+            16
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            12,
+            16,
+            8,
+            20
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "3729df3c-fde6-8e55-83f2-45c8cf53670a"
+    },
+    {
+      "name": "Left Leg",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        -0.1,
+        0,
+        -2
+      ],
+      "to": [
+        3.9,
+        12,
+        2
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        -0.03744001388549805,
+        0,
+        0
+      ],
+      "uv_offset": [
+        16,
+        48
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            20,
+            52,
+            24,
+            64
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            16,
+            52,
+            20,
+            64
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            28,
+            52,
+            32,
+            64
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            24,
+            52,
+            28,
+            64
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            24,
+            52,
+            20,
+            48
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            28,
+            48,
+            24,
+            52
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "40514c77-fe66-f7fa-2f74-ec7d4c8c20a8"
+    },
+    {
+      "name": "Head",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        -4,
+        24,
+        -4
+      ],
+      "to": [
+        4,
+        32,
+        4
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        0,
+        0,
+        0
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            40,
+            8,
+            48,
+            16
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            32,
+            8,
+            40,
+            16
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            56,
+            8,
+            64,
+            16
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            48,
+            8,
+            56,
+            16
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            48,
+            8,
+            40,
+            0
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            56,
+            0,
+            48,
+            8
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "fe6cb237-94c0-a777-589e-28b1348d0e1c",
+      "inflate": 0.5
+    },
+    {
+      "name": "Body",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        -4,
+        12,
+        -2
+      ],
+      "to": [
+        4,
+        24,
+        2
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        0,
+        0,
+        0
+      ],
+      "uv_offset": [
+        16,
+        16
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            20,
+            36,
+            28,
+            48
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            16,
+            36,
+            20,
+            48
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            32,
+            36,
+            40,
+            48
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            28,
+            36,
+            32,
+            48
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            28,
+            36,
+            20,
+            32
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            36,
+            32,
+            28,
+            36
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "1992eb79-db93-7d2f-577d-e939ca7112a7",
+      "inflate": 0.25
+    },
+    {
+      "name": "Right Arm",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        4,
+        12,
+        -2
+      ],
+      "to": [
+        8,
+        24,
+        2
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        0,
+        0,
+        0
+      ],
+      "uv_offset": [
+        40,
+        16
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            44,
+            36,
+            48,
+            48
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            40,
+            36,
+            44,
+            48
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            52,
+            36,
+            56,
+            48
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            48,
+            36,
+            52,
+            48
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            48,
+            36,
+            44,
+            32
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            52,
+            32,
+            48,
+            36
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "cd3961db-9a82-4036-48c9-6f0c0f5ff492",
+      "inflate": 0.25
+    },
+    {
+      "name": "Left Arm",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        -8,
+        12,
+        -2
+      ],
+      "to": [
+        -4,
+        24,
+        2
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        0,
+        0,
+        0
+      ],
+      "uv_offset": [
+        32,
+        48
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            52,
+            52,
+            56,
+            64
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            48,
+            52,
+            52,
+            64
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            60,
+            52,
+            64,
+            64
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            56,
+            52,
+            60,
+            64
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            56,
+            52,
+            52,
+            48
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            60,
+            48,
+            56,
+            52
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "6ebcfd34-e49e-13cf-4fe4-5168544f581d",
+      "inflate": 0.25
+    },
+    {
+      "name": "Right Leg",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        -3.9,
+        0,
+        -2
+      ],
+      "to": [
+        0.1,
+        12,
+        2
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        0.03744001388549805,
+        0,
+        0
+      ],
+      "uv_offset": [
+        0,
+        16
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            4,
+            36,
+            8,
+            48
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            0,
+            36,
+            4,
+            48
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            12,
+            36,
+            16,
+            48
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            8,
+            36,
+            12,
+            48
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            8,
+            36,
+            4,
+            32
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            12,
+            32,
+            8,
+            36
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "67227267-5728-6632-bfe5-b68dfca3edda",
+      "inflate": 0.25
+    },
+    {
+      "name": "Left Leg",
+      "rescale": false,
+      "locked": false,
+      "from": [
+        -0.1,
+        0,
+        -2
+      ],
+      "to": [
+        3.9,
+        12,
+        2
+      ],
+      "autouv": 0,
+      "color": 0,
+      "origin": [
+        -0.03744001388549805,
+        0,
+        0
+      ],
+      "uv_offset": [
+        16,
+        48
+      ],
+      "faces": {
+        "north": {
+          "uv": [
+            4,
+            52,
+            8,
+            64
+          ],
+          "texture": 0
+        },
+        "east": {
+          "uv": [
+            0,
+            52,
+            4,
+            64
+          ],
+          "texture": 0
+        },
+        "south": {
+          "uv": [
+            12,
+            52,
+            16,
+            64
+          ],
+          "texture": 0
+        },
+        "west": {
+          "uv": [
+            8,
+            52,
+            12,
+            64
+          ],
+          "texture": 0
+        },
+        "up": {
+          "uv": [
+            8,
+            52,
+            4,
+            48
+          ],
+          "texture": 0
+        },
+        "down": {
+          "uv": [
+            12,
+            48,
+            8,
+            52
+          ],
+          "texture": 0
+        }
+      },
+      "uuid": "79fd4620-0638-4b17-dde8-7912e6713b30",
+      "inflate": 0.25
+    }
+  ],
+  "outliner": [
+    {
+      "name": "model",
+      "origin": [
+        0,
+        0,
+        0
+      ],
+      "color": 0,
+      "uuid": "7faeac9f-c0d7-3388-e070-b585d13e9bc6",
+      "export": true,
+      "isOpen": true,
+      "locked": false,
+      "visibility": true,
+      "autouv": 0,
+      "children": [
+        {
+          "name": "Head",
+          "origin": [
+            0,
+            24,
+            0
+          ],
+          "uuid": "36d6b66f-29a5-1c3a-a9b2-3a623d5b093a",
+          "export": true,
+          "isOpen": true,
+          "locked": false,
+          "visibility": true,
+          "autouv": 0,
+          "children": [
+            "5104fb89-1a1a-e54e-8ea7-a3d422092d34",
+            "fe6cb237-94c0-a777-589e-28b1348d0e1c"
+          ]
+        },
+        {
+          "name": "Body",
+          "origin": [
+            0,
+            24,
+            0
+          ],
+          "uuid": "c6e264bb-1995-8bff-5219-133f84c0375f",
+          "export": true,
+          "isOpen": true,
+          "locked": false,
+          "visibility": true,
+          "autouv": 0,
+          "children": [
+            "537a1485-6b1a-1a8b-5a45-b46940212841",
+            "1992eb79-db93-7d2f-577d-e939ca7112a7"
+          ]
+        },
+        {
+        "name": "RightArm",
+        "origin": [
+          5,
+          22,
+          0
+          ],
+          "uuid": "80471ca3-4418-b60a-7ddb-ea4203c4b426",
+          "export": true,
+          "isOpen": true,
+          "locked": false,
+          "visibility": true,
+          "autouv": 0,
+          "children": [
+            "1120b3a0-bd40-cec6-d45a-f9c09fe6bd59",
+            "cd3961db-9a82-4036-48c9-6f0c0f5ff492"
+          ]
+        },
+        {
+        "name": "LeftArm",
+        "origin": [
+          -5,
+          22,
+          0
+          ],
+          "uuid": "6cf941fc-831e-8f37-ffe3-ec8a9e7da7ad",
+          "export": true,
+          "isOpen": true,
+          "locked": false,
+          "visibility": true,
+          "autouv": 0,
+          "children": [
+            "38ae66fa-1d04-98fe-7c9f-80d6d927c476",
+            "6ebcfd34-e49e-13cf-4fe4-5168544f581d"
+          ]
+        },
+        {
+          "name": "RightLeg",
+          "origin": [
+            -1.9,
+            12,
+            0
+          ],
+          "uuid": "effb1715-03da-1e40-3f78-23b543364775",
+          "export": true,
+          "isOpen": true,
+          "locked": false,
+          "visibility": true,
+          "autouv": 0,
+          "children": [
+            "3729df3c-fde6-8e55-83f2-45c8cf53670a",
+            "67227267-5728-6632-bfe5-b68dfca3edda"
+          ]
+        },
+        {
+          "name": "LeftLeg",
+          "origin": [
+            1.9,
+            12,
+            0
+          ],
+          "uuid": "9d6c2fa2-e5c9-2c91-13bb-e1beee58ca0e",
+          "export": true,
+          "isOpen": true,
+          "locked": false,
+          "visibility": true,
+          "autouv": 0,
+          "children": [
+            "40514c77-fe66-f7fa-2f74-ec7d4c8c20a8",
+            "79fd4620-0638-4b17-dde8-7912e6713b30"
+          ]
+        }
+      ]
+    }
+  ],
+  "textures": [
+    {
+      "path": "/home/ace/Programming/Minecraft/WorldSeedEntityEngine/src/test/resources/bbmodel/steve.png",
+      "name": "steve.png",
+      "folder": "",
+      "namespace": "",
+      "id": "0",
+      "particle": false,
+      "render_mode": "normal",
+      "visible": true,
+      "mode": "bitmap",
+      "saved": false,
+      "uuid": "7073fa2a-3dd2-730b-f192-db9edb75c207",
+      "source": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAACTUlEQVR4Xu1bvUoDQRDeE0ExvQlERFHwAWzSW9rZ+Aj2PodJoZVVnkArHyIIdmkEwR8MJGIbwcaVISdcxnVnz93lLnefjcXu7c5+O/PNN7ubRAl/N8NnbevS715YR7jqnyXSHEW2i8YRAJ3dDaONg4dXRQC0my1j+2gyVgAAHoAQEMMMHFAgAuLugASrngYPxl1rnm8NT6wOenl7bm1fPn63tq/u9EQvjBkhCQHQaa6b8/zkTREAW62Gsf1pPFUEQGN709g+fXxRBMBKe8/Y/jm6VwBgETzgdH/mAdej2UYetWf/e3c18YDaAwAOqDoJ2tJM5dMgXzyv/3m9L5W3sc8PfO3j6/0lQrLSl9f7LvV9bOnsax8AYAgYPSDbp/IhwGsBTnpc63Ntf9hIVVGKWl7SlGoFaXzJPklqz9UCA6b9udbn2p60PBn4U0vw73m8SePx/tL40ngutQYAyFaD8ACEwHz97xJj4ACQILIA0iB0QHqourBCKKvAaieFY565L8LYhV5KlAEgAFCGXSjSBnhAkeiXYW54QBl2IZcNa1qrjyTYxpkGovcCwSbItTiXzgAAHoAQAAcQVwQiwr9IkKYoLxG6kKVjn1os0oYFAHD0FOduvvf3vt87G5p2DO4Bvvf3vt8DgJwIRPGAkO8L8r5PyLl+/1QX+32B7/2/BIi3B8S8XXa5m5QeQAAAAYFKe8CSVvorsYe5FQCtlE4ESVzmEAAA8ACEQH05gOKfEsC/SZAIMD0UsBJlmUlQ0gBBDj0AAPvZXej3BbGl8Dck67KM7ElDfgAAAABJRU5ErkJggg==",
+      "relative_path": "../steve.png"
+    }
+  ],
+  "animations": [
+    {
+      "uuid": "19467591-ad5e-b55a-f152-f9717f26c050",
+      "name": "dab",
+      "loop": "once",
+      "override": false,
+      "length": 2,
+      "snapping": 20,
+      "selected": false,
+      "anim_time_update": "",
+      "blend_weight": "",
+      "start_delay": "",
+      "loop_delay": "",
+      "animators": {
+        "36d6b66f-29a5-1c3a-a9b2-3a623d5b093a": {
+          "name": "Head",
+          "keyframes": [
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": "0",
+                  "z": "0"
+                }
+              ],
+              "uuid": "a72ae329-4f0b-b08d-8f66-f85be9912698",
+              "time": 0,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": 32.5,
+                  "y": 0,
+                  "z": 0
+                }
+              ],
+              "uuid": "198b1592-c9e8-d161-1155-a87ee8e081a1",
+              "time": 0.45,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": "0",
+                  "z": "0"
+                }
+              ],
+              "uuid": "bafaa86c-6877-15a0-01a2-8a4ef6788471",
+              "time": 1.8,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": 32.5,
+                  "y": 0,
+                  "z": 0
+                }
+              ],
+              "uuid": "13b0ac91-9b3e-b701-a239-aa9b51e18343",
+              "time": 1.45,
+              "color": -1,
+              "interpolation": "linear"
+            }
+          ]
+        },
+        "80471ca3-4418-b60a-7ddb-ea4203c4b426": {
+          "name": "RightArm",
+          "keyframes": [
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": "0",
+                  "z": "0"
+                }
+              ],
+              "uuid": "07ce2e66-858b-4001-65f8-144c1152b772",
+              "time": 0,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": -47.5,
+                  "y": 0,
+                  "z": -100
+                }
+              ],
+              "uuid": "65073d92-a0da-1de1-dc8a-28be02514aca",
+              "time": 0.45,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": 0,
+                  "z": "100"
+                }
+              ],
+              "uuid": "f14e103b-bb71-0401-e922-661b4d403cfe",
+              "time": 0.85,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": -47.5,
+                  "y": 0,
+                  "z": -100
+                }
+              ],
+              "uuid": "f09867cc-ea33-6f5c-140c-77eed2b03429",
+              "time": 1.25,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": "0",
+                  "z": "0"
+                }
+              ],
+              "uuid": "42d8c0ba-9dd7-c8f2-43cc-adf3fd9520d0",
+              "time": 1.8,
+              "color": -1,
+              "interpolation": "linear"
+            }
+          ]
+        },
+        "6cf941fc-831e-8f37-ffe3-ec8a9e7da7ad": {
+          "name": "LeftArm",
+          "keyframes": [
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": "0",
+                  "z": "0"
+                }
+              ],
+              "uuid": "afe5fbf8-4f8e-957a-ca33-fbf47b6c36c5",
+              "time": 0,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "z": -100
+                }
+              ],
+              "uuid": "eec5ffce-c00f-6b52-a294-3296f274702c",
+              "time": 0.45,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "-47.5",
+                  "y": 0,
+                  "z": "100"
+                }
+              ],
+              "uuid": "5459fe31-1c20-3e6b-1241-52f8051c5b1e",
+              "time": 0.85,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": 0,
+                  "y": 0,
+                  "z": -100
+                }
+              ],
+              "uuid": "2ea11f77-f276-ffdc-bd4d-370f6bc034d5",
+              "time": 1.25,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": "0",
+                  "z": "0"
+                }
+              ],
+              "uuid": "839a3c4d-ec9d-8054-e028-3b7493ad490e",
+              "time": 1.8,
+              "color": -1,
+              "interpolation": "linear"
+            }
+          ]
+        },
+        "9d6c2fa2-e5c9-2c91-13bb-e1beee58ca0e": {
+          "name": "LeftLeg",
+          "keyframes": [
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": "0",
+                  "z": "0"
+                }
+              ],
+              "uuid": "a064e2eb-bdb2-ca58-fe3f-61354e79967e",
+              "time": 0,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": 10,
+                  "y": 0,
+                  "z": 0
+                }
+              ],
+              "uuid": "47bc767f-8cf8-13b2-87b3-e4f6b18cc04d",
+              "time": 1.45,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": "0",
+                  "z": "0"
+                }
+              ],
+              "uuid": "342059fb-8a37-fbe0-3a2f-b050152e3c5b",
+              "time": 1.8,
+              "color": -1,
+              "interpolation": "linear"
+            }
+          ]
+        },
+        "c6e264bb-1995-8bff-5219-133f84c0375f": {
+          "name": "Body",
+          "keyframes": [
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": "0",
+                  "z": "0"
+                }
+              ],
+              "uuid": "c3e8b0f2-6f67-2f5c-fcfe-456da83e51c4",
+              "time": 0,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": 5,
+                  "y": 0,
+                  "z": 0
+                }
+              ],
+              "uuid": "19b04d2b-4ed1-7743-bab3-98573839b4c2",
+              "time": 1.45,
+              "color": -1,
+              "interpolation": "linear"
+            },
+            {
+              "channel": "rotation",
+              "data_points": [
+                {
+                  "x": "0",
+                  "y": "0",
+                  "z": "0"
+                }
+              ],
+              "uuid": "cc8e918e-66c5-b40c-8e7e-9061646c243c",
+              "time": 1.8,
+              "color": -1,
+              "interpolation": "linear"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/test/resources/resourcepack_template/assets/minecraft/shaders/core/entity.fsh
+++ b/src/test/resources/resourcepack_template/assets/minecraft/shaders/core/entity.fsh
@@ -25,19 +25,45 @@ in vec4 overlayColor;
 in vec2 texCoord0;
 in vec2 texCoord1;
 flat in int playerPart;
+flat in int playerSlim;
 out vec4 fragColor;
 
+const vec4[] playerSubUvs = vec4[](
+    vec4(4,0,8,4), vec4(8,0,12,4), vec4(0,4,4,16), vec4(4,4,8,16), vec4(8,4,12,16), vec4(12,4,16,16),
+    vec4(4,0,7,4), vec4(7,0,10,4), vec4(0,4,4,16), vec4(4,4,7,16), vec4(7,4,11,16), vec4(11,4,14,16),
+    vec4(4,0,12,4), vec4(12,0,20,4), vec4(0,4,4,16), vec4(4,4,12,16), vec4(12,4,16,16), vec4(16,4,24,16)
+);
+const vec2[] playerOrigins = vec2[](
+    vec2(40,16), vec2(40,32), vec2(32,48), vec2(48,48), vec2(16,16),
+    vec2(16,32), vec2(0,16), vec2(0,32), vec2(16,48), vec2(0,48)
+);
+
+vec2 remapPlayerUv(vec2 sourceUv) {
+    vec2 sourcePixel = sourceUv * 64.0;
+    int outerLayer = sourcePixel.x >= 32.0 ? 1 : 0;
+    sourcePixel.x -= float(outerLayer) * 32.0;
+    int faceId;
+    vec2 sourceMin;
+    if (sourcePixel.y < 8.0) {
+        faceId = sourcePixel.x < 16.0 ? 0 : 1;
+        sourceMin = vec2(faceId == 0 ? 8.0 : 16.0, 0.0);
+    } else {
+        faceId = 2 + int(clamp(floor(sourcePixel.x / 8.0), 0.0, 3.0));
+        sourceMin = vec2(float(faceId - 2) * 8.0, 8.0);
+    }
+    int shapeOffset = (playerSlim != 0 && playerPart <= 2) ? 6 : (playerPart == 3 ? 12 : 0);
+    vec4 target = playerSubUvs[shapeOffset + faceId];
+    vec2 targetOffset = mix(target.xy, target.zw, (sourcePixel - sourceMin) / 8.0);
+    vec2 targetOrigin = playerOrigins[2 * (playerPart - 1) + outerLayer];
+    return (targetOrigin + targetOffset) / 64.0;
+}
+
 void main() {
-    vec4 color = texture(Sampler0, texCoord0);
+    vec2 sampleUv = playerPart > 0 ? remapPlayerUv(texCoord0) : texCoord0;
+    vec4 color = texture(Sampler0, sampleUv);
 #ifdef ALPHA_CUTOUT
     if (color.a < ALPHA_CUTOUT) discard;
 #endif
-    if (color.a < 1.0 && playerPart > 0) {
-        vec4 under = texture(Sampler0, texCoord1);
-        if (color.a < 0.75 && int(gl_FragCoord.x + gl_FragCoord.y) % 2 == 0) discard;
-        color.rgb = mix(under.rgb, color.rgb, min(1.0, color.a * 2.0));
-        color.a = 1.0;
-    }
 #ifdef PER_FACE_LIGHTING
     vec4 faceVertexColor = gl_FrontFacing ? vertexPerFaceColorFront : vertexPerFaceColorBack;
 #else

--- a/src/test/resources/resourcepack_template/assets/minecraft/shaders/core/entity.vsh
+++ b/src/test/resources/resourcepack_template/assets/minecraft/shaders/core/entity.vsh
@@ -40,10 +40,13 @@ out vec4 overlayColor;
 out vec2 texCoord0;
 out vec2 texCoord1;
 flat out int playerPart;
+flat out int playerSlim;
 
 #define SPACING 1024.0
 #define MAXRANGE (0.5 * SPACING)
 
+// Target rectangles relative to each player-part skin origin, ordered as the
+// player-head source UVs identify them: UP, DOWN, WEST, NORTH, EAST, SOUTH.
 const vec4[] subuvs = vec4[](
     vec4(4,0,8,4), vec4(8,0,12,4), vec4(0,4,4,16), vec4(4,4,8,16), vec4(8,4,12,16), vec4(12,4,16,16),
     vec4(4,0,7,4), vec4(7,0,10,4), vec4(0,4,4,16), vec4(4,4,7,16), vec4(7,4,11,16), vec4(11,4,14,16),
@@ -59,31 +62,21 @@ void main() {
     texCoord0 = UV0;
     texCoord1 = vec2(0);
     playerPart = 0;
+    playerSlim = 0;
 
     ivec2 dim = textureSize(Sampler0, 0);
     if (ProjMat[2][3] != 0.0 && dim == ivec2(64)) {
         int partId = -int((Position.y - MAXRANGE) / SPACING);
         playerPart = partId;
         if (partId > 0 && partId <= 5) {
-            vec4 samp1 = texture(Sampler0, vec2(54.0/64.0, 20.0/64.0));
-            vec4 samp2 = texture(Sampler0, vec2(55.0/64.0, 20.0/64.0));
-            bool slim = samp1.a == 0.0 || (all(equal(samp1.rgb, vec3(0))) && all(equal(samp2.rgb, vec3(0))) && samp1.a == 1.0 && samp2.a == 1.0);
-            int outerLayer = (gl_VertexID / 24) % 2;
-            int faceId = (gl_VertexID % 24) / 4;
-            int vertexId = gl_VertexID % 4;
-            int subuvIndex = faceId + ((slim && partId <= 2) ? 6 : (partId == 3 ? 12 : 0));
             position.y += SPACING * partId;
-            vec2 uv = origins[2 * (partId - 1) + outerLayer];
-            vec2 uv2 = origins[2 * (partId - 1)];
-            vec4 s = subuvs[subuvIndex];
-            vec2 offset;
-            if (faceId == 1) {
-                offset = vertexId == 0 ? s.zw : vertexId == 1 ? s.xw : vertexId == 2 ? s.xy : s.zy;
-            } else {
-                offset = vertexId == 0 ? s.zy : vertexId == 1 ? s.xy : vertexId == 2 ? s.xw : s.zw;
-            }
-            texCoord0 = (uv + offset) / 64.0;
-            texCoord1 = (uv2 + offset) / 64.0;
+
+            vec4 slimProbe1 = texture(Sampler0, vec2(54.0/64.0, 20.0/64.0));
+            vec4 slimProbe2 = texture(Sampler0, vec2(55.0/64.0, 20.0/64.0));
+            bool slim = slimProbe1.a == 0.0
+                || (all(equal(slimProbe1.rgb, vec3(0))) && all(equal(slimProbe2.rgb, vec3(0)))
+                    && slimProbe1.a == 1.0 && slimProbe2.a == 1.0);
+            playerSlim = slim ? 1 : 0;
         }
     }
 


### PR DESCRIPTION
Implements #31.

- Render transparent WSEE entities as vanilla-compatible player models
- Match vanilla player geometry, skin layers, shader mapping, and bone pivots
- Apply automatic idle, walking, looking, and hand-swing poses
- Support standard Minestom main-hand and off-hand equipment APIs
- Keep held items attached through vanilla and loaded emote animations
- Expose the WSEE model and animation handler for custom emotes
- Support multiple independently animated model instances
- Document creation, movement, equipment, and animation usage
- Prepare the 13.0.0 major release

Validation:
- ./gradlew clean test javadoc
- Regression coverage verifies skin/shader mapping, vanilla poses, hand contexts, item replacement, clearing, animated attachment, and multiple models

Closes #31.