### PR TITLE
fix: clamp generated UVs for Minecraft 26.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ repositories {
 Add the library as a dependency
 ```
 dependencies {
-    implementation("net.worldseed.multipart:WorldSeedEntityEngine:13.0.0")
+    implementation("net.worldseed.multipart:WorldSeedEntityEngine:13.0.1")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ publishing {
     publications.create<MavenPublication>("maven") {
         groupId = "net.worldseed.multipart"
         artifactId = "WorldSeedEntityEngine"
-        version = "13.0.0"
+        version = "13.0.1"
 
         from(components["java"])
     }

--- a/src/main/java/net/worldseed/resourcepack/multipart/parser/ModelParser.java
+++ b/src/main/java/net/worldseed/resourcepack/multipart/parser/ModelParser.java
@@ -311,15 +311,29 @@ public class ModelParser {
         return res;
     }
 
-    private static UV convertUV(UV uv, int width, int height, boolean inverse) {
+    static UV convertUV(UV uv, int width, int height, boolean inverse) {
         double sx = uv.x1 * (16.0 / width);
         double sy = uv.y1 * (16.0 / height);
         double ex = uv.x2 * (16.0 / width);
         double ey = uv.y2 * (16.0 / height);
 
+        double minU = clampModelUv(sx);
+        double minV = clampModelUv(sy);
+        double maxU = clampModelUv(sx + ex);
+        double maxV = clampModelUv(sy + ey);
+
+        // Minecraft 26.2 inspects the pixels covered by every face while baking its
+        // translucency. UVs outside the texture now throw from NativeImage instead of
+        // being tolerated, which rejects the carrier item's entire range_dispatch model.
+        // Blockbench can emit slightly overflowing UVs (and much larger ones for helper
+        // cubes), so keep every generated endpoint inside the model texture.
         if (inverse)
-            return new UV(ex + sx, ey + sy, sx, sy, uv.texture, uv.rotation);
-        return new UV(sx, sy, ex + sx, ey + sy, uv.texture, uv.rotation);
+            return new UV(maxU, maxV, minU, minV, uv.texture, uv.rotation);
+        return new UV(minU, minV, maxU, maxV, uv.texture, uv.rotation);
+    }
+
+    private static double clampModelUv(double value) {
+        return Math.max(0.0, Math.min(16.0, value));
     }
 
     private static JsonObject mappingsToJson() {

--- a/src/test/java/net/worldseed/resourcepack/multipart/parser/ModelParserUvTest.java
+++ b/src/test/java/net/worldseed/resourcepack/multipart/parser/ModelParserUvTest.java
@@ -1,0 +1,31 @@
+package net.worldseed.resourcepack.multipart.parser;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ModelParserUvTest {
+    @Test
+    void clampsUvEndpointsToMinecraftModelBounds() {
+        var converted = ModelParser.convertUV(
+                new ModelParser.UV(-8, 127, 48, 2, "0", 0),
+                128, 128, false);
+
+        assertEquals(0.0, converted.x1());
+        assertEquals(15.875, converted.y1());
+        assertEquals(5.0, converted.x2());
+        assertEquals(16.0, converted.y2());
+    }
+
+    @Test
+    void preservesClampedEndpointsWhenUvIsInverted() {
+        var converted = ModelParser.convertUV(
+                new ModelParser.UV(-8, 127, 48, 2, "0", 0),
+                128, 128, true);
+
+        assertEquals(5.0, converted.x1());
+        assertEquals(16.0, converted.y1());
+        assertEquals(0.0, converted.x2());
+        assertEquals(15.875, converted.y2());
+    }
+}


### PR DESCRIPTION
## Summary
- clamp converted model UV endpoints to Minecraft's valid 0–16 range
- prevent one out-of-bounds model from invalidating the full range-dispatch bake on Minecraft 26.2
- add regression coverage for negative and oversized UVs
- release as 13.0.1

## Verification
- `./gradlew clean test assemble --no-daemon`
- launched the demo server and the Gradle rs client on Minecraft 26.2; the affected model rendered textured without the bake exception