### PR TITLE
Fix model interactions, idle animations, and format 5 models

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ publishing {
     publications.create<MavenPublication>("maven") {
         groupId = "net.worldseed.multipart"
         artifactId = "WorldSeedEntityEngine"
-        version = "13.0.1"
+        version = "13.0.2"
 
         from(components["java"])
     }
@@ -56,4 +56,12 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+tasks.register<JavaExec>("demoServer") {
+    group = "demo"
+    description = "Runs the example Minestom demo server (src/test/java/Main.java)"
+    mainClass.set("Main")
+    classpath = sourceSets["test"].runtimeClasspath
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }

--- a/src/main/java/net/worldseed/multipart/GenericModel.java
+++ b/src/main/java/net/worldseed/multipart/GenericModel.java
@@ -164,7 +164,7 @@ public interface GenericModel extends Viewable, EventHandler<@NonNull ModelEvent
 
     /**
      * The entity that owns/drives this model — the source of its position and viewers, and the entity
-     * that receives hits landed on the model's hitboxes (as normal Minestom events). Set automatically
+     * that receives hits landed on the model's hitboxes (as normal Minestom attack events). Set automatically
      * when the model is bound to a {@link ModelEntity}; null if the model is driven manually.
      *
      * @return the owning entity, or null

--- a/src/main/java/net/worldseed/multipart/ModelEngine.java
+++ b/src/main/java/net/worldseed/multipart/ModelEngine.java
@@ -10,6 +10,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.EventListener;
+import net.minestom.server.event.entity.EntityAttackEvent;
 import net.minestom.server.event.entity.EntityDamageEvent;
 import net.minestom.server.event.player.PlayerEntityInteractEvent;
 import net.minestom.server.event.player.PlayerPacketEvent;
@@ -47,13 +48,28 @@ public class ModelEngine {
     // A hit on a model hitbox (an INTERACTION/BoneEntity) is surfaced as a NORMAL Minestom event on the
     // model's owner entity (see GenericModel#getOwner / ModelEntity) — no custom WSEE events to hook.
     private static final EventListener<@NonNull PlayerEntityInteractEvent> playerInteractListener = EventListener.of(PlayerEntityInteractEvent.class, event -> {
-        if (event.getTarget() instanceof BoneEntity bone) {
-            Entity owner = bone.getModel().getOwner();
-            if (owner != null && owner != event.getTarget()) {
-                EventDispatcher.call(new PlayerEntityInteractEvent(event.getPlayer(), owner, event.getHand(), event.getInteractPosition()));
-            }
-        }
+        PlayerEntityInteractEvent ownerInteraction = ownerInteraction(event);
+        if (ownerInteraction != null) EventDispatcher.call(ownerInteraction);
     });
+
+    static PlayerEntityInteractEvent ownerInteraction(PlayerEntityInteractEvent event) {
+        if (!(event.getTarget() instanceof BoneEntity bone)) return null;
+        Entity owner = bone.getModel().getOwner();
+        if (owner == null || owner == event.getTarget()) return null;
+        return new PlayerEntityInteractEvent(event.getPlayer(), owner, event.getHand(), event.getInteractPosition());
+    }
+    private static final EventListener<@NonNull EntityAttackEvent> entityAttackListener = EventListener.of(EntityAttackEvent.class, event -> {
+        EntityAttackEvent ownerAttack = ownerAttack(event);
+        if (ownerAttack != null) EventDispatcher.call(ownerAttack);
+    });
+
+    static EntityAttackEvent ownerAttack(EntityAttackEvent event) {
+        if (!(event.getTarget() instanceof BoneEntity bone)) return null;
+        Entity owner = bone.getModel().getOwner();
+        if (owner == null || owner == event.getTarget()) return null;
+        return new EntityAttackEvent(event.getEntity(), owner);
+    }
+
     private static final EventListener<@NonNull EntityDamageEvent> entityDamageListener = EventListener.of(EntityDamageEvent.class, event -> {
         if (event.getEntity() instanceof BoneEntity bone) {
             event.setCancelled(true); // the hitbox entity itself never takes damage
@@ -76,6 +92,7 @@ public class ModelEngine {
         MinecraftServer.getGlobalEventHandler()
                 .addListener(playerListener)
                 .addListener(playerInteractListener)
+                .addListener(entityAttackListener)
                 .addListener(entityDamageListener);
 
         JsonObject map = GSON.fromJson(mappingsData, JsonObject.class);

--- a/src/main/java/net/worldseed/multipart/ModelEntity.java
+++ b/src/main/java/net/worldseed/multipart/ModelEntity.java
@@ -17,7 +17,8 @@ import org.jetbrains.annotations.NotNull;
  *   <li><b>position</b> — the model follows this entity every tick,</li>
  *   <li><b>lifecycle</b> — the model is destroyed with this entity,</li>
  *   <li><b>hits</b> — a hit on any of the model's hitboxes arrives as a <i>normal</i> Minestom
- *       {@link net.minestom.server.event.entity.EntityDamageEvent} /
+ *       {@link net.minestom.server.event.entity.EntityAttackEvent} (and the resulting
+ *       {@link net.minestom.server.event.entity.EntityDamageEvent}) /
  *       {@link net.minestom.server.event.player.PlayerEntityInteractEvent} on <b>this</b> entity
  *       (WSEE routes it via {@link GenericModel#getOwner()}); no custom events to hook.</li>
  * </ul>

--- a/src/main/java/net/worldseed/multipart/animations/AnimationHandlerImpl.java
+++ b/src/main/java/net/worldseed/multipart/animations/AnimationHandlerImpl.java
@@ -38,6 +38,10 @@ public class AnimationHandlerImpl implements AnimationHandler {
     private volatile AnimationEffectHandler effectHandler = AnimationHandler.DEFAULT_EFFECT_HANDLER;
 
     public AnimationHandlerImpl(GenericModel model) {
+        this(model, true);
+    }
+
+    AnimationHandlerImpl(GenericModel model, boolean scheduleTask) {
         this.model = model;
         if (model.getParts().isEmpty()) {
             throw new IllegalStateException(
@@ -45,7 +49,9 @@ public class AnimationHandlerImpl implements AnimationHandler {
                             "otherwise animation channels cannot bind to bones.");
         }
         loadDefaultAnimations();
-        this.task = MinecraftServer.getSchedulerManager().scheduleTask(this::tick, TaskSchedule.immediate(), TaskSchedule.tick(1), ExecutionType.TICK_START);
+        this.task = scheduleTask
+                ? MinecraftServer.getSchedulerManager().scheduleTask(this::tick, TaskSchedule.immediate(), TaskSchedule.tick(1), ExecutionType.TICK_START)
+                : null;
     }
 
     protected void loadDefaultAnimations() {
@@ -205,7 +211,12 @@ public class AnimationHandlerImpl implements AnimationHandler {
         int priority = this.animationPriorities().get(animation);
         this.repeating.remove(priority);
         if (activeRepeating == modelAnimation) {
-            activeRepeating = null;
+            Map.Entry<Integer, ModelAnimation> fallback = this.repeating.firstEntry();
+            activeRepeating = fallback == null ? null : fallback.getValue();
+            if (activeRepeating != null && playingOnce == null) {
+                activeRepeating.setDirection(AnimationDirection.FORWARD);
+                activeRepeating.play(true);
+            }
         }
     }
 
@@ -437,7 +448,7 @@ public class AnimationHandlerImpl implements AnimationHandler {
     }
 
     public void destroy() {
-        this.task.cancel();
+        if (this.task != null) this.task.cancel();
     }
 
     @Override

--- a/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneHitbox.java
+++ b/src/main/java/net/worldseed/multipart/model_bones/misc/ModelBoneHitbox.java
@@ -68,6 +68,7 @@ public class ModelBoneHitbox extends ModelBoneImpl implements HitboxBone {
                 InteractionMeta meta = (InteractionMeta) this.stand.getEntityMeta();
                 meta.setHeight((float) (sizeY / 4f) * scale);
                 meta.setWidth((float) (sizeX / 4f) * scale);
+                meta.setResponse(true);
 
                 this.stand.setBoundingBox(sizeX / 4f * scale, sizeY / 4f * scale, sizeX / 4f * scale);
             }

--- a/src/main/java/net/worldseed/resourcepack/multipart/generator/GeoGenerator.java
+++ b/src/main/java/net/worldseed/resourcepack/multipart/generator/GeoGenerator.java
@@ -6,12 +6,22 @@ import javax.json.*;
 import java.util.*;
 
 public class GeoGenerator {
-    private static List<JsonObject> parseRecursive(JsonObject obj, Map<String, JsonObject> cubeMap, Map<String, JsonObject> locators, Map<String, JsonObject> nullObjects, String parent) {
+    private static List<JsonObject> parseRecursive(JsonObject obj, Map<String, JsonObject> cubeMap, Map<String, JsonObject> locators, Map<String, JsonObject> nullObjects, Map<String, JsonObject> groupMap, String parent) {
         List<JsonObject> res = new ArrayList<>();
         float scale = 0.25f;
 
-        String name = getOutlinerName(obj);
-        JsonArray pivot = obj.getJsonArray("origin");
+        // bbmodel format 5.0 splits bone data (name/origin/rotation) into a top-level "groups"
+        // array, leaving only {uuid, isOpen, children} stubs in the outliner. When the stub has
+        // no name of its own, resolve the real bone data from the group that shares its uuid.
+        JsonObject boneData = obj;
+        JsonString uuid = obj.getJsonString("uuid");
+        if (uuid != null && obj.getJsonString("name") == null) {
+            JsonObject group = groupMap.get(uuid.getString());
+            if (group != null) boneData = group;
+        }
+
+        String name = getOutlinerName(boneData);
+        JsonArray pivot = boneData.getJsonArray("origin");
         if (pivot == null) {
             pivot = Json.createArrayBuilder().add(0).add(0).add(0).build();
         } else {
@@ -24,7 +34,7 @@ public class GeoGenerator {
 
         JsonArrayBuilder cubes = Json.createArrayBuilder();
 
-        JsonArray rotation = obj.getJsonArray("rotation");
+        JsonArray rotation = boneData.getJsonArray("rotation");
         if (rotation == null) {
             rotation = Json.createArrayBuilder().add(0).add(0).add(0).build();
         } else {
@@ -40,7 +50,7 @@ public class GeoGenerator {
 
         for (JsonValue child : children) {
             if (child.getValueType() == JsonValue.ValueType.OBJECT) {
-                res.addAll(parseRecursive(child.asJsonObject(), cubeMap, locators, nullObjects, name));
+                res.addAll(parseRecursive(child.asJsonObject(), cubeMap, locators, nullObjects, groupMap, name));
             } else if (child.getValueType() == JsonValue.ValueType.STRING) {
                 JsonObject cube = cubeMap.get(child.toString());
                 if (cube != null) {
@@ -98,9 +108,22 @@ public class GeoGenerator {
     }
 
     public static JsonArray generate(JsonArray elements, JsonArray outliner, Map<String, TextureGenerator.TextureData> textures) {
+        return generate(elements, outliner, null, textures);
+    }
+
+    public static JsonArray generate(JsonArray elements, JsonArray outliner, JsonArray groups, Map<String, TextureGenerator.TextureData> textures) {
         Map<String, JsonObject> blocks = new HashMap<>();
         Map<String, JsonObject> locators = new HashMap<>();
         Map<String, JsonObject> nullObjects = new HashMap<>();
+
+        Map<String, JsonObject> groupMap = new HashMap<>();
+        if (groups != null) {
+            for (var group : groups) {
+                JsonObject g = group.asJsonObject();
+                JsonString uuid = g.getJsonString("uuid");
+                if (uuid != null) groupMap.put(uuid.getString(), g);
+            }
+        }
 
         for (var element : elements) {
             JsonObject el = element.asJsonObject();
@@ -123,7 +146,7 @@ public class GeoGenerator {
         for (var outline : outliner) {
             if (outline instanceof JsonObject) {
                 JsonObject el = outline.asJsonObject();
-                bonesList.addAll(parseRecursive(el, blocks, locators, nullObjects, null));
+                bonesList.addAll(parseRecursive(el, blocks, locators, nullObjects, groupMap, null));
             }
         }
 

--- a/src/main/java/net/worldseed/resourcepack/multipart/generator/ModelGenerator.java
+++ b/src/main/java/net/worldseed/resourcepack/multipart/generator/ModelGenerator.java
@@ -35,7 +35,7 @@ public class ModelGenerator {
         }
 
         Map<String, TextureGenerator.TextureData> textures = TextureGenerator.generate(model.getJsonArray("textures"), mcmetas, width, height);
-        JsonArray bones = GeoGenerator.generate(model.getJsonArray("elements"), model.getJsonArray("outliner"), textures);
+        JsonArray bones = GeoGenerator.generate(model.getJsonArray("elements"), model.getJsonArray("outliner"), model.getJsonArray("groups"), textures);
 
         JsonObject description = Json.createObjectBuilder()
                 .add("identifier", "geometry.unknown")

--- a/src/test/java/Main.java
+++ b/src/test/java/Main.java
@@ -101,6 +101,12 @@ void main() throws Exception {
             ));
 
             player.sendMessage(Component.text("Run /spawn or /emote", NamedTextColor.YELLOW));
+
+            try {
+                new demo_models.bulbasaur.BulbasaurMob(lobby, new Pos(4.5, 1, 4.5));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         });
 
         // Logout
@@ -144,6 +150,6 @@ void main() throws Exception {
         }, TaskSchedule.tick(10), TaskSchedule.tick(10));
     }
 
-    minecraftServer.start("0.0.0.0", 25565);
+    minecraftServer.start("0.0.0.0", 25599);
     IO.println("Server startup done!");
 }

--- a/src/test/java/demo_models/bulbasaur/BulbasaurMob.java
+++ b/src/test/java/demo_models/bulbasaur/BulbasaurMob.java
@@ -8,18 +8,16 @@ import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.attribute.Attribute;
-import net.minestom.server.entity.damage.DamageType;
+import net.minestom.server.entity.damage.Damage;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.network.packet.server.play.ParticlePacket;
 import net.minestom.server.particle.Particle;
-import net.minestom.server.registry.RegistryKey;
 import net.minestom.server.timer.Task;
 import net.minestom.server.utils.position.PositionUtils;
 import net.minestom.server.utils.time.TimeUnit;
 import net.worldseed.multipart.animations.AnimationHandler;
 import net.worldseed.multipart.animations.AnimationHandlerImpl;
 import org.jetbrains.annotations.NotNull;
-import org.jspecify.annotations.NonNull;
 
 import java.util.List;
 import java.util.Set;
@@ -89,7 +87,7 @@ public class BulbasaurMob extends EntityCreature {
     }
 
     @Override
-    public boolean damage(@NotNull RegistryKey<@NonNull DamageType> type, float amount) {
+    public boolean damage(@NotNull Damage damage) {
         if (this.dying) return false;
         this.animationHandler.playOnce("animation.bulbasaur.cry", () -> {
         });
@@ -100,7 +98,28 @@ public class BulbasaurMob extends EntityCreature {
                 .buildTask(() -> this.model.setState("normal")).delay(7, TimeUnit.CLIENT_TICK)
                 .schedule();
 
-        return super.damage(type, amount);
+        return super.damage(damage);
+    }
+
+    /** Visible demo response for a right-click routed through the model hitbox. */
+    public void interact() {
+        if (this.dying) return;
+
+        this.animationHandler.playOnce("animation.bulbasaur.cry", () -> {
+        });
+
+        ParticlePacket packet = new ParticlePacket(
+                Particle.HEART,
+                this.position.x(),
+                this.position.y() + 1,
+                this.position.z(),
+                0.35f,
+                0.35f,
+                0.35f,
+                0.05f,
+                4
+        );
+        this.getViewers().forEach(viewer -> viewer.sendPacket(packet));
     }
 
     @Override

--- a/src/test/java/demo_models/bulbasaur/BulbasaurMoveGoal.java
+++ b/src/test/java/demo_models/bulbasaur/BulbasaurMoveGoal.java
@@ -48,7 +48,8 @@ public class BulbasaurMoveGoal extends GoalSelector {
 
         this.lastTargetPos = target.getPosition();
 
-        if (!navigator.getPathPosition().samePoint(lastTargetPos)) {
+        var pathPosition = navigator.getPathPosition();
+        if (pathPosition == null || !pathPosition.samePoint(lastTargetPos)) {
             navigator.setPathTo(lastTargetPos);
         } else {
             forceEnd = true;
@@ -85,6 +86,7 @@ public class BulbasaurMoveGoal extends GoalSelector {
     public void end() {
         this.entityCreature.getNavigator().setPathTo(null);
         this.animationHandler.stopRepeat("animation.bulbasaur.ground_walk");
+        this.animationHandler.playRepeat("animation.bulbasaur.ground_idle");
         this.forceEnd = false;
     }
 }

--- a/src/test/java/demo_models/gem_golem/GemGolemMob.java
+++ b/src/test/java/demo_models/gem_golem/GemGolemMob.java
@@ -10,14 +10,12 @@ import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.attribute.Attribute;
-import net.minestom.server.entity.damage.DamageType;
-import net.minestom.server.entity.damage.EntityDamage;
+import net.minestom.server.entity.damage.Damage;
 import net.minestom.server.entity.metadata.other.ArmorStandMeta;
 import net.minestom.server.entity.metadata.water.fish.PufferfishMeta;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.network.packet.server.play.ParticlePacket;
 import net.minestom.server.particle.Particle;
-import net.minestom.server.registry.RegistryKey;
 import net.minestom.server.timer.Task;
 import net.minestom.server.utils.position.PositionUtils;
 import net.minestom.server.utils.time.TimeUnit;
@@ -28,7 +26,6 @@ import net.worldseed.multipart.events.ModelControlEvent;
 import net.worldseed.multipart.events.ModelDismountEvent;
 import net.worldseed.multipart.model_bones.BoneEntity;
 import org.jetbrains.annotations.NotNull;
-import org.jspecify.annotations.NonNull;
 
 import java.util.List;
 import java.util.Set;
@@ -130,7 +127,7 @@ public class GemGolemMob extends EntityCreature {
     }
 
     @Override
-    public boolean damage(@NotNull RegistryKey<@NonNull DamageType> type, float value) {
+    public boolean damage(@NotNull Damage damage) {
         this.model.setState("hit");
 
         if (stateTask != null && stateTask.isAlive()) stateTask.cancel();
@@ -138,7 +135,7 @@ public class GemGolemMob extends EntityCreature {
                 .buildTask(() -> this.model.setState("normal")).delay(7, TimeUnit.CLIENT_TICK)
                 .schedule();
 
-        return super.damage(type, value);
+        return super.damage(damage);
     }
 
     @Override

--- a/src/test/java/demo_models/tuff_golem/TuffGolemMob.java
+++ b/src/test/java/demo_models/tuff_golem/TuffGolemMob.java
@@ -7,17 +7,15 @@ import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.attribute.Attribute;
-import net.minestom.server.entity.damage.DamageType;
+import net.minestom.server.entity.damage.Damage;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.network.packet.server.play.ParticlePacket;
 import net.minestom.server.particle.Particle;
-import net.minestom.server.registry.RegistryKey;
 import net.minestom.server.timer.Task;
 import net.minestom.server.utils.time.TimeUnit;
 import net.worldseed.multipart.animations.AnimationHandler;
 import net.worldseed.multipart.animations.AnimationHandlerImpl;
 import org.jetbrains.annotations.NotNull;
-import org.jspecify.annotations.NonNull;
 
 import java.util.List;
 import java.util.Set;
@@ -65,7 +63,7 @@ public class TuffGolemMob extends EntityCreature {
     }
 
     @Override
-    public boolean damage(@NotNull RegistryKey<@NonNull DamageType> type, float value) {
+    public boolean damage(@NotNull Damage damage) {
         this.model.setState("animated_head");
 
         if (stateTask != null && stateTask.isAlive()) stateTask.cancel();
@@ -73,7 +71,7 @@ public class TuffGolemMob extends EntityCreature {
                 .buildTask(() -> this.model.setState("normal")).delay(7, TimeUnit.CLIENT_TICK)
                 .schedule();
 
-        return super.damage(type, value);
+        return super.damage(damage);
     }
 
     @Override

--- a/src/test/java/events/CombatEvent.java
+++ b/src/test/java/events/CombatEvent.java
@@ -1,9 +1,11 @@
 package events;
 
+import demo_models.bulbasaur.BulbasaurMob;
 import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.entity.damage.EntityDamage;
 import net.minestom.server.event.GlobalEventHandler;
 import net.minestom.server.event.entity.EntityAttackEvent;
+import net.minestom.server.event.player.PlayerEntityInteractEvent;
 
 public class CombatEvent {
     public static void hook(GlobalEventHandler handler) {
@@ -11,6 +13,12 @@ public class CombatEvent {
             if (event.getTarget() instanceof LivingEntity target) {
                 int damage = 1;
                 target.damage(EntityDamage.fromEntity(event.getEntity(), damage));
+            }
+        });
+
+        handler.addListener(PlayerEntityInteractEvent.class, event -> {
+            if (event.getTarget() instanceof BulbasaurMob bulbasaur) {
+                bulbasaur.interact();
             }
         });
     }

--- a/src/test/java/events/PackEvent.java
+++ b/src/test/java/events/PackEvent.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 public class PackEvent {
     private static void startHttpServer(File zipFile, String hash) throws IOException {
-        HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+        HttpServer server = HttpServer.create(new InetSocketAddress(8081), 0);
         server.createContext("/pack", new PackHandler(zipFile, hash));
         server.start();
     }
@@ -48,7 +48,7 @@ public class PackEvent {
         handler.addListener(AsyncPlayerConfigurationEvent.class, event ->
             MinecraftServer.getSchedulerManager().scheduleTask(() -> {
                 final ResourcePackInfo resourcePackInfo = ResourcePackInfo.resourcePackInfo()
-                    .uri(URI.create("http://127.0.0.1:8080/pack?hash=" + hash))
+                    .uri(URI.create("http://127.0.0.1:8081/pack?hash=" + hash))
                     .hash(hash)
                     .build();
                 event.getPlayer().sendResourcePacks(resourcePackInfo);

--- a/src/test/java/net/worldseed/multipart/ModelEngineHitboxTest.java
+++ b/src/test/java/net/worldseed/multipart/ModelEngineHitboxTest.java
@@ -1,0 +1,87 @@
+package net.worldseed.multipart;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.entity.LivingEntity;
+import net.minestom.server.entity.Player;
+import net.minestom.server.entity.PlayerHand;
+import net.minestom.server.event.EventDispatcher;
+import net.minestom.server.event.entity.EntityAttackEvent;
+import net.minestom.server.event.player.PlayerEntityInteractEvent;
+import net.minestom.server.network.player.GameProfile;
+import net.worldseed.multipart.model_bones.BoneEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ModelEngineHitboxTest {
+    @Test
+    void redirectsHitboxAttackToModelOwner() {
+        var model = new TestModel();
+        var owner = new LivingEntity(EntityType.ZOMBIE);
+        var attacker = new LivingEntity(EntityType.ZOMBIE);
+        var hitbox = new BoneEntity(EntityType.INTERACTION, model, "hitbox");
+        model.setOwner(owner);
+
+        EntityAttackEvent forwarded = ModelEngine.ownerAttack(new EntityAttackEvent(attacker, hitbox));
+
+        assertSame(attacker, forwarded.getEntity());
+        assertSame(owner, forwarded.getTarget());
+    }
+
+    @Test
+    void ignoresOrdinaryEntitiesAndUnownedHitboxes() {
+        var attacker = new LivingEntity(EntityType.ZOMBIE);
+        var ordinaryTarget = new LivingEntity(EntityType.ZOMBIE);
+        assertNull(ModelEngine.ownerAttack(new EntityAttackEvent(attacker, ordinaryTarget)));
+
+        var model = new TestModel();
+        var hitbox = new BoneEntity(EntityType.INTERACTION, model, "hitbox");
+        assertNull(ModelEngine.ownerAttack(new EntityAttackEvent(attacker, hitbox)));
+    }
+
+    @Test
+    void redirectsHitboxInteractionToModelOwner() {
+        MinecraftServer.init();
+        try {
+            var model = new TestModel();
+            var owner = new LivingEntity(EntityType.ZOMBIE);
+            var hitbox = new BoneEntity(EntityType.INTERACTION, model, "hitbox");
+            var player = new Player(null, new GameProfile(UUID.randomUUID(), "test"));
+            var interactionPoint = new Vec(0.25, 0.5, -0.25);
+            model.setOwner(owner);
+            ModelEngine.loadMappings(new StringReader("{}"), Path.of("."));
+
+            var forwardedInteraction = new AtomicReference<PlayerEntityInteractEvent>();
+            MinecraftServer.getGlobalEventHandler().addListener(PlayerEntityInteractEvent.class, event -> {
+                if (event.getTarget() == owner) forwardedInteraction.set(event);
+            });
+
+            EventDispatcher.call(new PlayerEntityInteractEvent(player, hitbox, PlayerHand.OFF, interactionPoint));
+
+            PlayerEntityInteractEvent forwarded = forwardedInteraction.get();
+            assertNotNull(forwarded);
+            assertSame(player, forwarded.getPlayer());
+            assertSame(owner, forwarded.getTarget());
+            assertSame(PlayerHand.OFF, forwarded.getHand());
+            assertSame(interactionPoint, forwarded.getInteractPosition());
+        } finally {
+            MinecraftServer.stopCleanly();
+        }
+    }
+
+    private static final class TestModel extends GenericModelImpl {
+        @Override
+        public String getId() {
+            return "test";
+        }
+    }
+}

--- a/src/test/java/net/worldseed/multipart/animations/AnimationHandlerRepeatTest.java
+++ b/src/test/java/net/worldseed/multipart/animations/AnimationHandlerRepeatTest.java
@@ -1,0 +1,87 @@
+package net.worldseed.multipart.animations;
+
+import net.worldseed.multipart.GenericModel;
+import net.worldseed.multipart.model_bones.ModelBone;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AnimationHandlerRepeatTest {
+    @Test
+    void stoppingActiveRepeatResumesPreviousRepeat() {
+        GenericModel model = (GenericModel) Proxy.newProxyInstance(
+                GenericModel.class.getClassLoader(),
+                new Class<?>[]{GenericModel.class},
+                (_, method, _) -> method.getName().equals("getParts")
+                        ? List.of(dummyBone())
+                        : defaultValue(method.getReturnType()));
+        var handler = new TestHandler(model);
+        var idle = new TestAnimation("idle", 0);
+        var walk = new TestAnimation("walk", -1);
+        handler.registerAnimation(idle);
+        handler.registerAnimation(walk);
+
+        handler.playRepeat("idle");
+        handler.playRepeat("walk");
+        handler.stopRepeat("walk");
+
+        assertEquals("idle", handler.getRepeating());
+        assertTrue(idle.playCount >= 2, "idle must be restarted after walk stops");
+    }
+
+    private static ModelBone dummyBone() {
+        return (ModelBone) Proxy.newProxyInstance(
+                ModelBone.class.getClassLoader(), new Class<?>[]{ModelBone.class},
+                (_, method, _) -> defaultValue(method.getReturnType()));
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) return null;
+        if (type == boolean.class) return false;
+        if (type == char.class) return '\0';
+        if (type == byte.class) return (byte) 0;
+        if (type == short.class) return (short) 0;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0F;
+        return 0D;
+    }
+
+    private static final class TestHandler extends AnimationHandlerImpl {
+        private TestHandler(GenericModel model) {
+            super(model, false);
+        }
+
+        @Override
+        protected void loadDefaultAnimations() {
+        }
+    }
+
+    private static final class TestAnimation implements ModelAnimation {
+        private final String name;
+        private final int priority;
+        private AnimationHandler.AnimationDirection direction = AnimationHandler.AnimationDirection.PAUSE;
+        private int playCount;
+
+        private TestAnimation(String name, int priority) {
+            this.name = name;
+            this.priority = priority;
+        }
+
+        @Override public int priority() { return priority; }
+        @Override public int animationTime() { return 20; }
+        @Override public String name() { return name; }
+        @Override public AnimationHandler.AnimationDirection direction() { return direction; }
+        @Override public Set<String> getAnimatedBones() { return Set.of(); }
+        @Override public void setDirection(AnimationHandler.AnimationDirection direction) { this.direction = direction; }
+        @Override public void stop() { direction = AnimationHandler.AnimationDirection.PAUSE; }
+        @Override public void stop(Set<String> animatedBones) { stop(); }
+        @Override public void play(boolean resume) { playCount++; }
+        @Override public void tick() { }
+    }
+}

--- a/src/test/java/net/worldseed/resourcepack/multipart/generator/GeoGeneratorFormat5Test.java
+++ b/src/test/java/net/worldseed/resourcepack/multipart/generator/GeoGeneratorFormat5Test.java
@@ -1,0 +1,165 @@
+package net.worldseed.resourcepack.multipart.generator;
+
+import net.worldseed.resourcepack.PackBuilder;
+import org.junit.jupiter.api.Test;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GeoGeneratorFormat5Test {
+    private static final String CUBE_UUID = "09000000-0000-0000-0000-000000000001";
+    private static final String BODY_UUID = "09000000-0000-0000-0000-000000000002";
+    private static final String HEAD_UUID = "09000000-0000-0000-0000-000000000003";
+
+    @Test
+    void format5OutlinerStubsResolveBoneDataFromGroups() {
+        ModelGenerator.BBEntityModel model = ModelGenerator.generate(new PackBuilder.Model(format5Model(), "format5_test", null));
+
+        JsonObject head = bone(model, "head");
+        assertNotNull(head, "bone must exist under its real name, not its uuid");
+        assertArrayEquals(new double[]{0.0, 6.0, 1.0}, pivot(head), 1e-6);
+        assertArrayEquals(new double[]{-10.0, 20.0, 30.0}, rotation(head), 1e-6);
+        assertEquals("body", head.getString("parent"));
+        assertEquals(1, head.getJsonArray("cubes").size(), "the cube must attach to the head bone");
+
+        JsonObject body = bone(model, "body");
+        assertNotNull(body);
+        assertArrayEquals(new double[]{0.0, 3.0, 0.0}, pivot(body), 1e-6);
+
+        assertNull(bone(model, HEAD_UUID), "bones must never be registered under raw uuids");
+    }
+
+    @Test
+    void format5AnimationChannelsMatchGeoBoneNames() {
+        ModelGenerator.BBEntityModel model = ModelGenerator.generate(new PackBuilder.Model(format5Model(), "format5_test", null));
+
+        JsonObject bones = model.animations().getJsonObject("animations")
+                .getJsonObject("nod").getJsonObject("bones");
+        assertTrue(bones.containsKey("head"), "animation channel must be keyed by the real bone name");
+        assertNotNull(bone(model, "head"), "geo must expose a bone for the animation channel to bind to");
+    }
+
+    @Test
+    void preFormat5OutlinerStillParsesUnchanged() {
+        // pre-5.0 files embed name/origin/rotation in the outliner itself and carry no "groups" key
+        ModelGenerator.BBEntityModel model = ModelGenerator.generate(new PackBuilder.Model(format4Model(), "legacy", null));
+
+        JsonObject head = bone(model, "head");
+        assertNotNull(head);
+        assertArrayEquals(new double[]{0.0, 6.0, 1.0}, pivot(head), 1e-6);
+        assertArrayEquals(new double[]{-10.0, 20.0, 30.0}, rotation(head), 1e-6);
+        assertEquals(1, head.getJsonArray("cubes").size());
+    }
+
+    private static JsonObject bone(ModelGenerator.BBEntityModel model, String name) {
+        JsonArray bones = model.geo()
+                .getJsonArray("minecraft:geometry").getJsonObject(0)
+                .getJsonArray("bones");
+        for (JsonObject bone : bones.getValuesAs(JsonObject.class)) {
+            if (name.equals(bone.getString("name", null))) return bone;
+        }
+        return null;
+    }
+
+    private static double[] pivot(JsonObject bone) {
+        return toArray(bone.getJsonArray("pivot"));
+    }
+
+    private static double[] rotation(JsonObject bone) {
+        return toArray(bone.getJsonArray("rotation"));
+    }
+
+    private static double[] toArray(JsonArray array) {
+        return new double[]{
+                array.getJsonNumber(0).doubleValue(),
+                array.getJsonNumber(1).doubleValue(),
+                array.getJsonNumber(2).doubleValue()
+        };
+    }
+
+    private static String format5Model() {
+        return """
+                {
+                  "meta": {"format_version": "5.0", "model_format": "bedrock", "box_uv": true},
+                  "name": "format5_test",
+                  "resolution": {"width": 64, "height": 64},
+                  "elements": [%s],
+                  "groups": [
+                    {"name": "body", "uuid": "%s", "origin": [0, 12, 0], "rotation": [0, 0, 0], "children": []},
+                    {"name": "head", "uuid": "%s", "origin": [0, 24, 4], "rotation": [10, -20, 30], "children": []}
+                  ],
+                  "outliner": [
+                    {"uuid": "%s", "isOpen": true, "children": [
+                      {"uuid": "%s", "isOpen": true, "children": ["%s"]}
+                    ]}
+                  ],
+                  "textures": [],
+                  "animations": [
+                    {
+                      "uuid": "09000000-0000-0000-0000-000000000004",
+                      "name": "nod",
+                      "length": 1,
+                      "animators": {
+                        "%s": {
+                          "name": "head",
+                          "type": "bone",
+                          "keyframes": [
+                            {"channel": "rotation", "time": 0, "interpolation": "linear",
+                             "data_points": [{"x": 5, "y": 10, "z": -15}]}
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """.formatted(cubeJson(), BODY_UUID, HEAD_UUID, BODY_UUID, HEAD_UUID, CUBE_UUID, HEAD_UUID);
+    }
+
+    private static String format4Model() {
+        return """
+                {
+                  "meta": {"format_version": "4.10", "model_format": "bedrock", "box_uv": true},
+                  "name": "legacy",
+                  "resolution": {"width": 64, "height": 64},
+                  "elements": [%s],
+                  "outliner": [
+                    {
+                      "uuid": "%s", "name": "body", "origin": [0, 12, 0], "rotation": [0, 0, 0],
+                      "children": [
+                        {
+                          "uuid": "%s", "name": "head", "origin": [0, 24, 4], "rotation": [10, -20, 30],
+                          "children": ["%s"]
+                        }
+                      ]
+                    }
+                  ],
+                  "textures": []
+                }
+                """.formatted(cubeJson(), BODY_UUID, HEAD_UUID, CUBE_UUID);
+    }
+
+    private static String cubeJson() {
+        return """
+                {
+                  "name": "head_cube", "box_uv": true,
+                  "from": [-4, 24, -4], "to": [4, 32, 4], "origin": [0, 24, 0],
+                  "uv_offset": [0, 0],
+                  "faces": {
+                    "north": {"uv": [8, 8, 16, 16], "texture": 0},
+                    "east": {"uv": [0, 8, 8, 16], "texture": 0},
+                    "south": {"uv": [16, 8, 24, 16], "texture": 0},
+                    "west": {"uv": [24, 8, 32, 16], "texture": 0},
+                    "up": {"uv": [8, 8, 16, 0], "texture": 0},
+                    "down": {"uv": [16, 0, 24, 8], "texture": 0}
+                  },
+                  "type": "cube", "uuid": "%s"
+                }
+                """.formatted(CUBE_UUID);
+    }
+}


### PR DESCRIPTION
## Summary
- route left-click attacks and right-click interactions from model hitboxes to their owner entities
- resume idle animation after temporary movement/one-shot animations
- support Blockbench format 5 group-backed outliners
- refresh the Bulbasaur demo with distinct attack and interaction behavior
- release as 13.0.2

## Verification
- `./gradlew clean build --no-daemon`
- live Minecraft 26.2 client: left-click attack and right-click cry interaction
- Wizworth demo model removed from generated demo assets