### PR TITLE
Fix EmotePlayer construction near viewers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ publishing {
     publications.create<MavenPublication>("maven") {
         groupId = "net.worldseed.multipart"
         artifactId = "WorldSeedEntityEngine"
-        version = "13.0.2"
+        version = "13.0.3"
 
         from(components["java"])
     }

--- a/src/main/java/net/worldseed/gestures/EmotePlayer.java
+++ b/src/main/java/net/worldseed/gestures/EmotePlayer.java
@@ -191,7 +191,11 @@ public class EmotePlayer extends ModelEntity {
 
     @Override
     public @NotNull ItemStack getEquipment(@NotNull EquipmentSlot slot) {
-        return visualEquipment.getOrDefault(slot, ItemStack.AIR);
+        // ModelEntity attaches the carrier to its instance from its super constructor.
+        // That can make Minestom request an equipment packet before this subclass's
+        // field initializers have run. Treat that brief construction window as empty.
+        Map<EquipmentSlot, ItemStack> equipment = visualEquipment;
+        return equipment == null ? ItemStack.AIR : equipment.getOrDefault(slot, ItemStack.AIR);
     }
 
     @Override

--- a/src/test/java/net/worldseed/gestures/EmoteHeldItemTest.java
+++ b/src/test/java/net/worldseed/gestures/EmoteHeldItemTest.java
@@ -7,12 +7,16 @@ import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
+import net.minestom.server.entity.Player;
 import net.minestom.server.entity.PlayerSkin;
 import net.minestom.server.entity.EquipmentSlot;
 import net.minestom.server.entity.metadata.display.ItemDisplayMeta;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
+import net.minestom.server.network.packet.server.SendablePacket;
+import net.minestom.server.network.player.GameProfile;
+import net.minestom.server.network.player.PlayerConnection;
 import net.worldseed.multipart.ModelLoader;
 import net.worldseed.multipart.animations.AnimationHandler;
 import net.worldseed.multipart.animations.BoneAnimation;
@@ -22,10 +26,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStreamReader;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -73,6 +81,25 @@ class EmoteHeldItemTest {
         assertEquals(ItemStack.AIR, player.getItemInMainHand());
         assertEquals(ItemStack.AIR, player.getItemInOffHand());
         player.remove();
+    }
+
+    @Test
+    void emotePlayerCanSpawnWhileAViewerIsAlreadyInRange() {
+        PlayerConnection connection = new PlayerConnection() {
+            @Override public void sendPacket(SendablePacket packet) { }
+            @Override public SocketAddress getRemoteAddress() {
+                return new InetSocketAddress("127.0.0.1", 25565);
+            }
+        };
+        Player viewer = new Player(connection, new GameProfile(UUID.randomUUID(), "viewer"));
+        viewer.setInstance(instance, Pos.ZERO).join();
+
+        EmotePlayer emote = assertDoesNotThrow(() ->
+                new EmotePlayer(instance, new Pos(1, 0, 1), new PlayerSkin("", "")));
+
+        assertTrue(emote.getViewers().contains(viewer));
+        emote.remove();
+        viewer.remove();
     }
 
     @Test


### PR DESCRIPTION
Fixes #78.

## Summary
- avoid querying uninitialized visual equipment while Minestom attaches an EmotePlayer carrier
- add a regression test with a viewer already present in range
- release as 13.0.3

## Verification
- `./gradlew clean build --no-daemon`
- live Minecraft 26.2 `/emote` demo renders and plays the dab animation