### PR TITLE
Fix reversed emote facing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ publishing {
     publications.create<MavenPublication>("maven") {
         groupId = "net.worldseed.multipart"
         artifactId = "WorldSeedEntityEngine"
-        version = "13.0.3"
+        version = "13.0.4"
 
         from(components["java"])
     }

--- a/src/main/java/net/worldseed/gestures/EmoteModel.java
+++ b/src/main/java/net/worldseed/gestures/EmoteModel.java
@@ -158,7 +158,11 @@ public class EmoteModel extends GenericModelImpl {
         VanillaPlayerPose.Pose pose = VanillaPlayerPose.pose(state);
         pose.rotations().forEach((bone, rotation) -> {
             ProceduralBoneAnimation animation = vanillaRotations.get(bone);
-            if (animation != null) animation.setTransform(rotation);
+            // Vanilla ModelPart uses a Y-down basis. Emote and Blockbench animations
+            // use the generated display model's Y-up basis, so normalize vanilla input
+            // here instead of mirroring every animation at render time.
+            if (animation != null) animation.setTransform(new Vec(
+                    -rotation.x(), -rotation.y(), rotation.z()));
         });
         pose.translations().forEach((bone, translation) -> {
             ProceduralBoneAnimation animation = vanillaTranslations.get(bone);

--- a/src/main/java/net/worldseed/gestures/ModelBoneEmote.java
+++ b/src/main/java/net/worldseed/gestures/ModelBoneEmote.java
@@ -163,7 +163,7 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
         // The arm display is centred around the generated head-item model's origin.
         // Vanilla's ModelPart hand pivot is 0.11 blocks below that display origin.
         Quaternion entityFacing = new Quaternion(new Vec(0, -this.model.getGlobalRotation(), 0));
-        double armXDelta = Math.toRadians(getPropagatedRotation().x() - ITEM_POSE_ARM_X);
+        double armXDelta = Math.toRadians(nativeRotation().x() - ITEM_POSE_ARM_X);
         // The generated arm display and vanilla's hand matrix use different origins.
         // When the arm bobs around X, that origin separation becomes a depth arc.
         // Keep the correction in entity-local space so both arms and every yaw share
@@ -179,12 +179,12 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
     }
 
     private Quaternion calculateHeldItemGripRotation() {
-        Quaternion local = calculateFinalAngle(new Quaternion(getPropagatedRotation()));
+        Quaternion local = new Quaternion(nativeRotation());
         return new Quaternion(new Vec(0, 180, 0)).multiply(local);
     }
 
     private Quaternion calculateHeldItemRotation() {
-        Quaternion local = calculateFinalAngle(new Quaternion(getPropagatedRotation()));
+        Quaternion local = new Quaternion(nativeRotation());
         // DisplayRenderer applies the entity yaw as R_y(-yaw). Vanilla's player root
         // is R_y(180-yaw), so metadata must contribute the invariant R_y(180):
         // R_y(-yaw) * R_y(180) * arm == R_y(180-yaw) * arm.
@@ -225,18 +225,18 @@ public class ModelBoneEmote extends ModelBoneImpl implements ModelBoneViewable {
         return q.toEuler();
     }
 
-    /**
-     * PlayerModel rotations are expressed in Minecraft ModelPart coordinates (Y points
-     * down). The generated display cubes use the Blockbench basis (Y points up), so X/Y
-     * rotation components must be reflected for the visible cube. Held items retain the
-     * native ModelPart basis used by ItemInHandLayer.
-     */
     private Quaternion calculateVisibleRotation() {
-        Point rotation = getPropagatedRotation();
-        Quaternion q = calculateFinalAngle(new Quaternion(new Vec(
-                -rotation.x(), -rotation.y(), rotation.z())));
+        // Stored rotations are in the authored Blockbench/display basis. Vanilla
+        // ModelPart poses are converted when they enter EmoteModel.
+        Quaternion q = calculateFinalAngle(new Quaternion(getPropagatedRotation()));
         Quaternion global = new Quaternion(new Vec(0, 180 - this.model.getGlobalRotation(), 0));
         return global.multiply(q);
+    }
+
+    /** Convert the display/Blockbench arm basis back to ItemInHandLayer's native basis. */
+    private Point nativeRotation() {
+        Point rotation = getPropagatedRotation();
+        return new Vec(-rotation.x(), -rotation.y(), rotation.z());
     }
 
     @Override

--- a/src/test/java/net/worldseed/gestures/EmoteHeldItemTest.java
+++ b/src/test/java/net/worldseed/gestures/EmoteHeldItemTest.java
@@ -18,6 +18,7 @@ import net.minestom.server.network.packet.server.SendablePacket;
 import net.minestom.server.network.player.GameProfile;
 import net.minestom.server.network.player.PlayerConnection;
 import net.worldseed.multipart.ModelLoader;
+import net.worldseed.multipart.Quaternion;
 import net.worldseed.multipart.animations.AnimationHandler;
 import net.worldseed.multipart.animations.BoneAnimation;
 import net.worldseed.multipart.model_bones.ModelBoneImpl;
@@ -170,6 +171,25 @@ class EmoteHeldItemTest {
         double expectedDepth = 0.585033 - 1.0546875 * Math.sin(Math.toRadians(18.0));
         assertEquals(arm.getEntity().getPosition().z() + expectedDepth,
                 arm.getHeldItemEntity().getPosition().z(), 1.0e-6);
+        model.destroy();
+    }
+
+    @Test
+    void authoredEmoteRotationKeepsItsBlockbenchFacing() {
+        EmoteModel model = model();
+        ModelBoneEmote arm = (ModelBoneEmote) model.getPart("RightArm");
+        Point authoredRotation = new Vec(30, 20, 10);
+        arm.addAnimation(rotation(authoredRotation));
+
+        ModelBoneImpl.beginDrawFrame();
+        model.draw();
+
+        Quaternion expected = new Quaternion(new Vec(0, 180, 0))
+                .multiply(new Quaternion(authoredRotation));
+        assertArrayEquals(new float[]{
+                        (float) expected.x(), (float) expected.y(),
+                        (float) expected.z(), (float) expected.w()},
+                visibleMeta(model, "RightArm").getRightRotation(), 1.0e-6f);
         model.destroy();
     }
 


### PR DESCRIPTION
## Summary
- preserve authored Blockbench/emote rotations in the display coordinate space
- normalize vanilla player pose rotations at the input boundary
- convert rotations back only for held-item rendering
- add a regression test for authored emote facing
- release as 13.0.4

## Verification
- live-tested `/emote` in the Minecraft 26.2 client
- `./gradlew clean build --no-daemon --console=plain`